### PR TITLE
v2.0.1: fix migration publishing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+## [2.0.1] - 2026-05-30
+
+### Fixed
+- Migrations now publish correctly via `vendor:publish --tag=modules-blog-migrations`. The previous bare-name `hasMigrations()` list pointed at non-existent source paths (real files are timestamp-prefixed), so consumers got an empty publish. Switched to `discoversMigrations()`.
+
 ## [2.0.0] - 2026-05-28
 
 ### Added

--- a/docs/superpowers/plans/2026-05-29-kurtmodules-events-v1.md
+++ b/docs/superpowers/plans/2026-05-29-kurtmodules-events-v1.md
@@ -1,0 +1,2434 @@
+# `ozankurt/laravel-modules-events` v1.0 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `ozankurt/laravel-modules-events` v1.0.0 — a payment-agnostic event management module covering events, sessions, tickets, applications, requirements, sale queue, waitlist, refunds, transfers, add-ons, price tiers, discount codes, referrals, sponsors, announcements, audit log, templates, GDPR helpers, optional Notifications. Headless. Filament admin lands in v1.1.
+
+**Architecture:** Five sub-aggregates (Catalog, Ticketing, Attendance, Eligibility, Flow) under `Kurt\Modules\Events\`. Top-level `Events` facade exposes ergonomic API. Same scaffold as Core/Blog/Library/Forum/Chat (Spatie's `PackageServiceProvider`, Pest 3, PHPStan 8, Pint, GH Actions matrix). 32 tables.
+
+**Tech Stack:** PHP 8.4, Laravel 12/13, `ozankurt/laravel-modules-core ^2.0`, `spatie/laravel-medialibrary ^11`, `spatie/laravel-translatable ^6.11`, `cviebrock/eloquent-sluggable ^11|^12`, Pest 3, Testbench 10, Larastan 3.
+
+**Spec:** [2026-05-29-kurtmodules-events-v1-spec.md](../specs/2026-05-29-kurtmodules-events-v1-spec.md)
+
+**Working directory:** `D:\Code\Projects\KurtModules-Events`. The repo does NOT yet exist on GitHub; Task 0 creates it.
+
+**Defer to v1.1:** Filament resources (Task 21 in spec), Scout integration. Document in CHANGELOG.
+
+---
+
+## File structure
+
+Code goes under `src/` organised by sub-aggregate plus cross-cutting folders:
+
+```
+src/
+  Catalog/
+    Contracts/EventChatBridge.php
+    Enums/{EventStatus, EventVisibility, RecurrenceFrequency, OrganizerRole, AttendeeListVisibility}.php
+    Models/{Event, EventCategory, EventTag, EventOrganizer, EventTemplate, Session}.php
+    Observers/{EventObserver, SessionObserver}.php
+    Support/{IcsExporter, RecurrenceExpander, EventCloner}.php
+  Ticketing/
+    Enums/{TicketTypeMode, OrderStatus, TicketStatus, DiscountKind, DiscountApplicationScope, DiscountScope, AddOnPurchaseStatus}.php
+    Models/{TicketType, PriceTier, Order, OrderItem, OrderItemAssignment, Ticket, TicketAddOn, TicketAddOnPurchase, ReferralLink, DiscountCode, DiscountCodeUsage}.php
+    Observers/{OrderObserver, TicketObserver}.php
+    Support/{PriceCalculator, QrTokenSigner, TicketIssuer, TransferEngine, ReferralAttributor}.php
+  Attendance/
+    Enums/{ApplicationStatus, AttendeeStatus, AnnouncementAudience, AnnouncementRecipientStatus}.php
+    Models/{Attendee, Application, AttendanceForm, AttendanceResponse, Announcement, AnnouncementRecipient}.php
+    Observers/{AttendeeObserver, ApplicationObserver}.php
+    Support/AnnouncementDispatcher.php
+  Eligibility/
+    Contracts/{DocumentVerifier, RequirementEvaluator, GroupResolver}.php
+    Engine/{RequirementEngine, CheckResult, EvaluationOutcome}.php
+    Enums/{RequirementType, CheckStatus, VerificationStatus}.php
+    Evaluators/{AgeMinEvaluator, AgeMaxEvaluator, DocumentEvaluator, GroupMembershipEvaluator, GenderEvaluator, FreeFormEvaluator, CustomRuleEvaluator}.php
+    Models/{Requirement, RequirementCheck, DocumentUpload, DocumentVerification}.php
+  Flow/
+    Contracts/QueueChallengeProvider.php
+    Enums/{QueueStatus, WaitlistStatus, RefundStatus, RefundReason, SponsorStatus, PayoutStatus}.php
+    Models/{SaleQueueEntry, WaitlistEntry, Refund, Sponsor, SponsorTier, SponsorCompTicket, PayoutLedgerEntry, CheckInAttempt, AuditLogEntry}.php
+    Support/{QueueReleaser, WaitlistPromoter, RefundCoordinator, PayoutAccruer, AuditLogWriter}.php
+  Concerns/{IsEventOrganizer, IsEventAttendee}.php
+  Contracts/{EventOrganizer, EventAttendee}.php
+  Events/  -- domain events; many files
+  Exceptions/  -- typed exceptions
+  Notifications/  -- optional Laravel Notifications
+  Policies/{EventPolicy, TicketTypePolicy, OrderPolicy, ApplicationPolicy, RefundPolicy, QueuePolicy, WaitlistPolicy}.php
+  Providers/EventsServiceProvider.php
+  Support/Events.php  -- top-level facade
+```
+
+---
+
+## Task 0: Create GitHub repo + local scaffold
+
+**Files:**
+- New: `D:\Code\Projects\KurtModules-Events\` (entire directory)
+
+- [ ] **Step 1: Create GitHub repo + clone**
+
+```bash
+gh repo create OzanKurt/KurtModules-Events --public --description "Payment-agnostic event management for Laravel: events, tickets, applications, queue, waitlist, refunds, transfers, requirements, sponsors, announcements, GDPR helpers." --license=mit
+cd D:/Code/Projects
+git clone https://github.com/OzanKurt/KurtModules-Events.git
+cd KurtModules-Events
+```
+
+- [ ] **Step 2: Copy `SECURITY.md` from `../KurtModules-Core/`**
+
+```bash
+cp ../KurtModules-Core/SECURITY.md .
+```
+
+- [ ] **Step 3: Commit initial files + create v1.0 branch**
+
+```bash
+git add SECURITY.md
+git commit -m "chore: bootstrap repo with SECURITY.md"
+git push origin master
+git switch -c v1.0
+```
+
+---
+
+## Task 1: composer.json
+
+**Files:**
+- Create: `composer.json`
+
+- [ ] **Step 1: Write composer.json**
+
+```json
+{
+  "name": "ozankurt/laravel-modules-events",
+  "description": "Payment-agnostic event management for Laravel: events, tickets, applications, queue, waitlist, refunds, transfers, requirements, sponsors, announcements.",
+  "keywords": ["laravel", "filament", "kurtmodules", "events", "ticketing"],
+  "license": "MIT",
+  "authors": [{ "name": "Ozan Kurt", "email": "ozankurt2@gmail.com" }],
+  "require": {
+    "php": "^8.4",
+    "illuminate/contracts": "^12.0 || ^13.0",
+    "illuminate/database": "^12.0 || ^13.0",
+    "illuminate/support": "^12.0 || ^13.0",
+    "cviebrock/eloquent-sluggable": "^11.0 || ^12.0",
+    "ozankurt/laravel-modules-core": "^2.0",
+    "spatie/laravel-medialibrary": "^11.0",
+    "spatie/laravel-package-tools": "^1.92",
+    "spatie/laravel-translatable": "^6.11"
+  },
+  "require-dev": {
+    "filament/filament": "^3.0 || ^4.0 || ^5.0",
+    "larastan/larastan": "^3.0",
+    "laravel/pint": "^1.18",
+    "mockery/mockery": "^1.6",
+    "orchestra/testbench": "^10.0",
+    "pestphp/pest": "^3.0",
+    "pestphp/pest-plugin-laravel": "^3.0",
+    "rector/rector": "^2.0"
+  },
+  "autoload": { "psr-4": { "Kurt\\Modules\\Events\\": "src/" } },
+  "autoload-dev": {
+    "psr-4": {
+      "Kurt\\Modules\\Events\\Tests\\": "tests/",
+      "Database\\Factories\\Kurt\\Modules\\Events\\": "database/factories/"
+    }
+  },
+  "extra": { "laravel": { "providers": ["Kurt\\Modules\\Events\\Providers\\EventsServiceProvider"] } },
+  "repositories": [
+    { "type": "vcs", "url": "https://github.com/OzanKurt/KurtModules-Core" }
+  ],
+  "config": { "sort-packages": true, "allow-plugins": { "pestphp/pest-plugin": true } },
+  "scripts": {
+    "test": "vendor/bin/pest",
+    "lint": "vendor/bin/pint --test",
+    "format": "vendor/bin/pint",
+    "stan": "vendor/bin/phpstan analyse --memory-limit=2G"
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true
+}
+```
+
+- [ ] **Step 2: composer install**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe composer.phar install --no-interaction
+```
+Expected: clean install with `ozankurt/laravel-modules-core v2.0.0` resolved from VCS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add composer.json composer.lock
+git commit -m "feat: composer scaffold for laravel-modules-events v1"
+```
+
+---
+
+## Task 2: Dev configs
+
+**Files:**
+- Copy from `../KurtModules-Chat/`: `pint.json`, `phpstan.neon`, `rector.php`, `.gitattributes`, `.gitignore`, `phpunit.xml.dist`.
+
+- [ ] **Step 1: Copy + commit**
+
+```bash
+cp ../KurtModules-Chat/pint.json .
+cp ../KurtModules-Chat/phpstan.neon .
+cp ../KurtModules-Chat/rector.php .
+cp ../KurtModules-Chat/.gitattributes .
+cp ../KurtModules-Chat/.gitignore .
+cp ../KurtModules-Chat/phpunit.xml.dist .
+
+git add pint.json phpstan.neon rector.php .gitattributes .gitignore phpunit.xml.dist
+git commit -m "chore: add pint, phpstan, rector, phpunit configs"
+```
+
+- [ ] **Step 2: Verify**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pint --test
+```
+Expected: pass.
+
+---
+
+## Task 3: config/events.php
+
+**Files:**
+- Create: `config/events.php`
+
+- [ ] **Step 1: Write config**
+
+(Use the full block from spec §19. Reproduced abbreviated below — engineer should copy verbatim from spec.)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+return [
+    'currency' => env('EVENTS_DEFAULT_CURRENCY', 'USD'),
+
+    'queue' => [
+        'enabled' => true,
+        'active_concurrency' => 100,
+        'active_window_seconds' => 300,
+        'heartbeat_timeout_seconds' => 60,
+    ],
+
+    'waitlist' => [
+        'enabled' => true,
+        'claim_window_seconds' => 600,
+    ],
+
+    'recurrence' => [
+        'enabled' => true,
+        'window_days' => 90,
+    ],
+
+    'refunds' => [
+        'consumer_protection_window_days' => 14,
+    ],
+
+    'transfers' => [
+        'allowed_by_default' => true,
+    ],
+
+    'tax' => [
+        'enabled' => true,
+    ],
+
+    'publishing' => [
+        'require_approval' => false,
+    ],
+
+    'audit' => [
+        'enabled' => true,
+        'capture_context' => true,
+    ],
+
+    'anti_bot' => [
+        'queue_challenge' => null,
+    ],
+
+    'chat_bridge' => [
+        'provider' => null,
+    ],
+
+    'gdpr' => [
+        'retention_days' => null,
+        'anonymize_audit_log_actor' => true,
+    ],
+
+    'payouts' => [
+        'auto_accrue_on_order_paid' => true,
+    ],
+
+    'documents' => [
+        'disk' => env('EVENTS_DOCUMENT_DISK', 'private'),
+        'verifier' => null,
+    ],
+
+    'requirements' => [
+        'evaluators' => [
+            'age_min' => \Kurt\Modules\Events\Eligibility\Evaluators\AgeMinEvaluator::class,
+            'age_max' => \Kurt\Modules\Events\Eligibility\Evaluators\AgeMaxEvaluator::class,
+            'document' => \Kurt\Modules\Events\Eligibility\Evaluators\DocumentEvaluator::class,
+            'group_membership' => \Kurt\Modules\Events\Eligibility\Evaluators\GroupMembershipEvaluator::class,
+            'gender' => \Kurt\Modules\Events\Eligibility\Evaluators\GenderEvaluator::class,
+            'free_form_question' => \Kurt\Modules\Events\Eligibility\Evaluators\FreeFormEvaluator::class,
+            'custom_rule' => \Kurt\Modules\Events\Eligibility\Evaluators\CustomRuleEvaluator::class,
+        ],
+        'group_resolver' => null,
+    ],
+
+    'notifications' => [
+        'enabled' => false,
+        'channels' => ['mail', 'database'],
+    ],
+
+    'broadcasting' => [
+        'enabled' => true,
+    ],
+
+    'reminders' => [
+        'enabled' => true,
+        'before_hours' => [24, 1],
+    ],
+
+    'orders' => [
+        'pending_timeout_minutes' => 15,
+    ],
+
+    'check_in' => [
+        'token_lifetime_minutes' => 0,
+        'replay_protection' => true,
+    ],
+
+    'search' => [
+        'geo' => [
+            'enabled' => false,
+            'distance_unit' => 'km',
+        ],
+    ],
+
+    'models' => [
+        // overrides for downstream model swaps
+    ],
+];
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add config/events.php
+git commit -m "feat(events): add config file"
+```
+
+---
+
+## Task 4: Enums
+
+**Files:** all under `src/{Catalog,Ticketing,Attendance,Eligibility,Flow}/Enums/`. Plus unit tests under `tests/Unit/Enums/`.
+
+Strict TDD for each enum: failing test (class not found) → implementation → green.
+
+- [ ] **Step 1: Catalog enums**
+
+`src/Catalog/Enums/EventStatus.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Events\Catalog\Enums;
+
+enum EventStatus: string
+{
+    case Draft = 'draft';
+    case PendingApproval = 'pending_approval';
+    case Published = 'published';
+    case Cancelled = 'cancelled';
+    case Completed = 'completed';
+}
+```
+
+Repeat for `EventVisibility` (Public/Unlisted/Private), `RecurrenceFrequency` (None/Daily/Weekly/Monthly/Yearly), `OrganizerRole` (Owner/Manager/Scanner), `AttendeeListVisibility` (Private/OrganizerOnly/AttendeesOnly/Public). Cases-and-values test per enum.
+
+- [ ] **Step 2: Ticketing enums**
+
+`TicketTypeMode` (Open/Application/Rsvp), `OrderStatus` (Pending/Paid/Cancelled/Refunded/PartiallyRefunded), `TicketStatus` (Issued/Cancelled/Refunded/CheckedIn/Transferred), `DiscountKind` (Percent/FlatAmount), `DiscountApplicationScope` (Order/PerTicket), `DiscountScope` (Global/EventsSubset), `AddOnPurchaseStatus` (Pending/Paid/Cancelled/Refunded). Cases-and-values test per enum.
+
+- [ ] **Step 3: Attendance enums**
+
+`ApplicationStatus` (Pending/Approved/Rejected/Withdrawn/Expired), `AttendeeStatus` (Registered/Cancelled/CheckedIn/NoShow), `AnnouncementAudience` (All/Registered/CheckedIn/ByTicketType/BySession), `AnnouncementRecipientStatus` (Pending/Sent/Failed/Opened). Cases-and-values test per enum.
+
+- [ ] **Step 4: Eligibility enums**
+
+`RequirementType` (AgeMin=age_min/AgeMax=age_max/Document/GroupMembership=group_membership/Gender/FreeFormQuestion=free_form_question/CustomRule=custom_rule), `CheckStatus` (Pending/Passed/Failed/Waived), `VerificationStatus` (Pending/Verified/Rejected). Cases-and-values test per enum.
+
+- [ ] **Step 5: Flow enums**
+
+`QueueStatus` (Waiting/Active/Expired/Completed/Abandoned), `WaitlistStatus` (Waiting/Offered/Claimed/Expired), `RefundStatus` (Pending/Processed/Failed), `RefundReason` (Rejection/CancelledEvent=cancelled_event/AttendeeRequest=attendee_request/OrganizerInitiated=organizer_initiated/Other), `SponsorStatus` (Pending/Active/Cancelled), `PayoutStatus` (Accrued/PaidOut=paid_out/Reversed). Cases-and-values test per enum.
+
+- [ ] **Step 6: Run + commit**
+
+```bash
+vendor/bin/pest tests/Unit/Enums
+git add src/{Catalog,Ticketing,Attendance,Eligibility,Flow}/Enums tests/Unit/Enums
+git commit -m "feat(events): add enums across sub-aggregates"
+```
+Expected: ~30 enum tests pass.
+
+---
+
+## Task 5: Migrations
+
+32 anonymous migration files under `database/migrations/`, timestamped `2026_05_29_NNNNNN_*.php` (NNNNNN reserves order across sub-aggregates). Use exact column definitions from spec §5.
+
+Order is significant — tables with FKs come after their referents. Sequence:
+
+1. `…_000010_create_events_categories_table.php`
+2. `…_000020_create_events_tags_table.php`
+3. `…_000030_create_events_events_table.php` (FK categories)
+4. `…_000040_create_events_event_tag_table.php`
+5. `…_000050_create_events_event_organizers_table.php` (FK events)
+6. `…_000055_create_events_event_templates_table.php`
+7. `…_000060_create_events_sessions_table.php` (FK events)
+8. `…_000070_create_events_attendance_forms_table.php` (FK events)
+9. `…_000080_create_events_ticket_types_table.php` (FK events + attendance_forms)
+10. `…_000085_create_events_ticket_type_session_table.php` (pivot)
+11. `…_000090_create_events_price_tiers_table.php` (FK ticket_types)
+12. `…_000100_create_events_ticket_add_ons_table.php` (FK events)
+13. `…_000105_create_events_sponsor_tiers_table.php` (FK events + ticket_types)
+14. `…_000110_create_events_referral_links_table.php` (FK events)
+15. `…_000115_create_events_discount_codes_table.php`
+16. `…_000118_create_events_discount_code_event_table.php` (pivot)
+17. `…_000120_create_events_orders_table.php` (FK events + referral_links + discount_codes)
+18. `…_000130_create_events_order_items_table.php` (FK orders + ticket_types + price_tiers)
+19. `…_000135_create_events_order_item_assignments_table.php` (FK order_items)
+20. `…_000140_create_events_tickets_table.php` (FK order_items + assignments + ticket_types + events)
+21. `…_000145_create_events_session_check_ins_table.php` (FK sessions + tickets)
+22. `…_000150_create_events_ticket_add_on_purchases_table.php` (FK tickets + add_ons + order_items)
+23. `…_000160_create_events_applications_table.php` (FK events + ticket_types + orders)
+24. `…_000170_create_events_attendees_table.php` (FK tickets)
+25. `…_000175_create_events_attendance_responses_table.php` (FK attendees + forms)
+26. `…_000180_create_events_announcements_table.php` (FK events)
+27. `…_000185_create_events_announcement_recipients_table.php` (FK announcements + attendees)
+28. `…_000190_create_events_requirements_table.php` (FK events + ticket_types)
+29. `…_000200_create_events_requirement_checks_table.php` (FK attendees + applications + requirements)
+30. `…_000210_create_events_document_uploads_table.php` (FK attendees + requirements)
+31. `…_000220_create_events_document_verifications_table.php` (FK uploads)
+32. `…_000230_create_events_discount_code_usages_table.php` (FK discount_codes + orders)
+33. `…_000240_create_events_sponsors_table.php` (FK events + sponsor_tiers + orders)
+34. `…_000245_create_events_sponsor_comp_tickets_table.php` (FK sponsors + tickets)
+35. `…_000250_create_events_sale_queue_entries_table.php` (FK events)
+36. `…_000260_create_events_waitlist_entries_table.php` (FK ticket_types)
+37. `…_000270_create_events_refunds_table.php` (FK orders + tickets)
+38. `…_000280_create_events_payout_ledger_table.php` (FK orders)
+39. `…_000290_create_events_check_in_attempts_table.php` (FK tickets)
+40. `…_000300_create_events_audit_log_table.php`
+
+Each migration is an anonymous class `extends Migration` with `up()` and `down()`. Copy column definitions from spec §5 exactly.
+
+- [ ] **Step 1–40: Write each migration in order**
+
+For each migration: write the file, do not run yet (some tables FK to later ones — but ordering above resolves that). Verify per file.
+
+- [ ] **Step 41: Run + verify**
+
+```bash
+vendor/bin/pest tests/Feature/MigrationsTest.php
+```
+
+Add a smoke test under `tests/Feature/MigrationsTest.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+
+it('creates every events_* table', function () {
+    foreach ([
+        'events_categories', 'events_tags', 'events_events', 'events_event_tag',
+        'events_event_organizers', 'events_event_templates', 'events_sessions',
+        'events_attendance_forms', 'events_ticket_types', 'events_ticket_type_session',
+        'events_price_tiers', 'events_ticket_add_ons', 'events_sponsor_tiers',
+        'events_referral_links', 'events_discount_codes', 'events_discount_code_event',
+        'events_orders', 'events_order_items', 'events_order_item_assignments',
+        'events_tickets', 'events_session_check_ins', 'events_ticket_add_on_purchases',
+        'events_applications', 'events_attendees', 'events_attendance_responses',
+        'events_announcements', 'events_announcement_recipients', 'events_requirements',
+        'events_requirement_checks', 'events_document_uploads', 'events_document_verifications',
+        'events_discount_code_usages', 'events_sponsors', 'events_sponsor_comp_tickets',
+        'events_sale_queue_entries', 'events_waitlist_entries', 'events_refunds',
+        'events_payout_ledger', 'events_check_in_attempts', 'events_audit_log',
+    ] as $table) {
+        expect(Schema::hasTable($table))->toBeTrue("missing {$table}");
+    }
+});
+```
+
+- [ ] **Step 42: Commit**
+
+```bash
+git add database/migrations tests/Feature/MigrationsTest.php
+git commit -m "feat(events): add all v1 migrations across sub-aggregates"
+```
+
+---
+
+## Task 6: Catalog models + factories
+
+**Files:**
+- `src/Catalog/Models/{Event,EventCategory,EventTag,EventOrganizer,EventTemplate,Session}.php`
+- `database/factories/Catalog/{EventFactory,EventCategoryFactory,EventTagFactory,EventOrganizerFactory,EventTemplateFactory,SessionFactory}.php`
+
+For each model use `HasFactory` + `newFactory()` override (as in Blog/Library/Forum/Chat). Translatable strings via `HasTranslations`. Sluggable on Event + Session + EventTemplate + EventCategory + EventTag.
+
+- [ ] **Step 1: EventCategory model + factory**
+
+```php
+namespace Kurt\Modules\Events\Catalog\Models;
+
+class EventCategory extends Model
+{
+    use HasFactory, HasTranslations, Sluggable, SoftDeletes;
+    protected $table = 'events_categories';
+    public array $translatable = ['name', 'description'];
+    protected $fillable = ['parent_id','slug','name','description','position'];
+    public function sluggable(): array { return ['slug' => ['source' => 'name', 'onUpdate' => true]]; }
+    public function parent(): BelongsTo { return $this->belongsTo(self::class, 'parent_id'); }
+    public function children(): HasMany { return $this->hasMany(self::class, 'parent_id'); }
+    public function events(): HasMany { return $this->hasMany(Event::class, 'category_id'); }
+}
+```
+
+Factory definition + commit per model.
+
+- [ ] **Step 2: EventTag**
+
+Same pattern: HasTranslations + Sluggable, no SoftDeletes, slug + name + position.
+
+- [ ] **Step 3: Event** (largest)
+
+Translatable: `title`, `description`. Cast: `status` → EventStatus, `visibility` → EventVisibility, `attendee_list_visibility` → AttendeeListVisibility, `starts_at`, `ends_at`, `sale_starts_at`, `sale_ends_at`, `cancelled_at` → datetime, `recurrence_rule` → array, `reminder_intervals` → array.
+
+Relations:
+```php
+public function category(): BelongsTo { return $this->belongsTo(EventCategory::class); }
+public function tags(): BelongsToMany { return $this->belongsToMany(EventTag::class, 'events_event_tag')->withTimestamps(); }
+public function organizers(): HasMany { return $this->hasMany(EventOrganizer::class); }
+public function sessions(): HasMany { return $this->hasMany(Session::class); }
+public function ticketTypes(): HasMany { return $this->hasMany(TicketType::class); }
+public function orders(): HasMany { return $this->hasMany(Order::class); }
+public function attendees(): HasManyThrough { return $this->hasManyThrough(Attendee::class, Ticket::class); }
+public function parent(): BelongsTo { return $this->belongsTo(self::class, 'parent_event_id'); }
+public function occurrences(): HasMany { return $this->hasMany(self::class, 'parent_event_id'); }
+```
+
+Scopes (per spec §16.9):
+```php
+public function scopePublished(Builder $q): Builder { return $q->where('status', EventStatus::Published->value)->whereNull('cancelled_at'); }
+public function scopeUpcoming(Builder $q): Builder { return $q->where('starts_at', '>=', now()); }
+public function scopePast(Builder $q): Builder { return $q->where('starts_at', '<', now()); }
+public function scopeInCategory(Builder $q, EventCategory|int $cat): Builder { return $q->where('category_id', $cat instanceof EventCategory ? $cat->id : $cat); }
+public function scopeWithTags(Builder $q, array|int $tagIds, bool $matchAll = false): Builder { /* whereHas pattern */ }
+public function scopeOrganizedBy(Builder $q, Model $user): Builder { return $q->whereHas('organizers', fn ($o) => $o->where('user_id', $user->getKey())); }
+public function scopeNearLocation(Builder $q, float $lat, float $lng, float $radius): Builder
+{
+    if (! config('events.search.geo.enabled')) {
+        return $q->whereRaw('1=0'); // disabled
+    }
+    $unit = config('events.search.geo.distance_unit') === 'mi' ? 3959 : 6371;
+    return $q->whereNotNull('latitude')->whereNotNull('longitude')
+        ->selectRaw("*, ({$unit} * acos(cos(radians(?)) * cos(radians(latitude)) * cos(radians(longitude) - radians(?)) + sin(radians(?)) * sin(radians(latitude)))) AS distance", [$lat, $lng, $lat])
+        ->having('distance', '<=', $radius);
+}
+```
+
+Method:
+```php
+public function chatRoomId(): ?string
+{
+    $bridge = config('events.chat_bridge.provider');
+    if ($bridge === null) return null;
+    return app($bridge)->roomIdFor($this);
+}
+```
+
+Test (in `tests/Feature/Catalog/EventTest.php`):
+```php
+it('persists translatable title across locales', function () {
+    $user = StubUser::create(['email' => 'a@b.c']);
+    $event = Event::factory()->create(['title' => ['en' => 'Concert', 'tr' => 'Konser']]);
+    expect($event->getTranslation('title', 'tr'))->toBe('Konser');
+});
+
+it('filters published + upcoming via scopes', function () {
+    Event::factory()->create(['status' => EventStatus::Draft]);
+    Event::factory()->published()->upcoming()->create();
+    expect(Event::query()->published()->upcoming()->count())->toBe(1);
+});
+```
+
+Factory:
+```php
+public function definition(): array
+{
+    $title = $this->faker->unique()->sentence(4);
+    return [
+        'slug' => str($title)->slug(),
+        'title' => ['en' => $title],
+        'status' => EventStatus::Draft,
+        'visibility' => EventVisibility::Public,
+        'attendee_list_visibility' => AttendeeListVisibility::OrganizerOnly,
+        'starts_at' => now()->addDays(30),
+        'ends_at' => now()->addDays(30)->addHours(2),
+        'timezone' => 'UTC',
+    ];
+}
+public function published(): static { return $this->state(fn () => ['status' => EventStatus::Published]); }
+public function upcoming(): static { return $this->state(fn () => ['starts_at' => now()->addDays(7), 'ends_at' => now()->addDays(7)->addHours(2)]); }
+```
+
+- [ ] **Step 4: EventOrganizer pivot model**
+
+```php
+class EventOrganizer extends Model
+{
+    use HasFactory;
+    protected $table = 'events_event_organizers';
+    protected $fillable = ['event_id','user_id','role','commission_basis_points'];
+    protected $casts = ['role' => OrganizerRole::class, 'commission_basis_points' => 'integer'];
+    public function event(): BelongsTo { return $this->belongsTo(Event::class); }
+    public function user(): BelongsTo { return $this->belongsTo(config('auth.providers.users.model'), 'user_id'); }
+}
+```
+
+- [ ] **Step 5: Session**
+
+Translatable `title`, `description`. Sluggable. Casts `starts_at`/`ends_at` → datetime.
+
+Relations: `event()`, `ticketTypes()` belongsToMany via `events_ticket_type_session`, `checkIns()` HasMany.
+
+- [ ] **Step 6: EventTemplate**
+
+```php
+class EventTemplate extends Model
+{
+    use HasFactory, Sluggable, SoftDeletes;
+    protected $table = 'events_event_templates';
+    protected $fillable = ['owner_id','slug','name','description','payload','is_public'];
+    protected $casts = ['payload' => 'array', 'is_public' => 'boolean'];
+    public function sluggable(): array { return ['slug' => ['source' => 'name']]; }
+    public function owner(): BelongsTo { return $this->belongsTo(config('auth.providers.users.model'), 'owner_id'); }
+}
+```
+
+- [ ] **Step 7: Run + commit**
+
+```bash
+vendor/bin/pint
+vendor/bin/phpstan analyse --memory-limit=2G
+vendor/bin/pest tests/Feature/Catalog tests/Unit
+git add src/Catalog database/factories/Catalog tests
+git commit -m "feat(events): add Catalog models, factories, scopes, chatRoomId bridge"
+```
+
+---
+
+## Task 7: Ticketing models + factories
+
+**Files:**
+- `src/Ticketing/Models/{TicketType,PriceTier,Order,OrderItem,OrderItemAssignment,Ticket,TicketAddOn,TicketAddOnPurchase,ReferralLink,DiscountCode,DiscountCodeUsage}.php`
+- Matching factories under `database/factories/Ticketing/`.
+
+Highlights per model (each gets a small TDD test):
+
+- [ ] **Step 1: TicketType**
+
+Translatable `name`, `description`. Casts `mode` → TicketTypeMode, `refundable`/`transferable`/`consumer_protection_exempt` → bool, `sale_starts_at`/`sale_ends_at` → datetime. Fillable includes all transfer/EU columns from spec §5.2.
+
+Relations:
+```php
+public function event(): BelongsTo { return $this->belongsTo(Event::class); }
+public function priceTiers(): HasMany { return $this->hasMany(PriceTier::class); }
+public function sessions(): BelongsToMany { return $this->belongsToMany(Session::class, 'events_ticket_type_session')->withTimestamps(); }
+public function tickets(): HasMany { return $this->hasMany(Ticket::class); }
+public function attendanceForm(): BelongsTo { return $this->belongsTo(AttendanceForm::class); }
+```
+
+Method:
+```php
+public function activePriceTier(?Carbon $at = null): ?PriceTier
+{
+    $when = $at ?? now();
+    return $this->priceTiers()->orderBy('position')->get()
+        ->first(fn (PriceTier $t) =>
+            ($t->starts_at === null || $t->starts_at <= $when) &&
+            ($t->ends_at === null || $t->ends_at > $when)
+        );
+}
+
+public function currentUnitPriceMinor(?Carbon $at = null): int
+{
+    return $this->activePriceTier($at)?->price_minor ?? $this->price_minor;
+}
+```
+
+- [ ] **Step 2: PriceTier**
+
+```php
+protected $casts = ['starts_at' => 'datetime', 'ends_at' => 'datetime', 'price_minor' => 'integer'];
+protected $fillable = ['ticket_type_id','name','starts_at','ends_at','price_minor','capacity','position'];
+public function ticketType(): BelongsTo { return $this->belongsTo(TicketType::class); }
+```
+
+- [ ] **Step 3: Order**
+
+```php
+protected $casts = ['status' => OrderStatus::class, 'paid_at' => 'datetime', 'assignment_completed_at' => 'datetime'];
+protected $fillable = ['event_id','user_id','status','subtotal_minor','discount_minor','tax_minor','total_minor','tax_rate_basis_points','currency','discount_code_id','referral_link_id','processor','processor_reference','metadata'];
+public function event(): BelongsTo { return $this->belongsTo(Event::class); }
+public function buyer(): BelongsTo { return $this->belongsTo(config('auth.providers.users.model'), 'user_id'); }
+public function items(): HasMany { return $this->hasMany(OrderItem::class); }
+public function tickets(): HasManyThrough { return $this->hasManyThrough(Ticket::class, OrderItem::class); }
+public function discountCode(): BelongsTo { return $this->belongsTo(DiscountCode::class); }
+public function referralLink(): BelongsTo { return $this->belongsTo(ReferralLink::class); }
+public function refunds(): HasMany { return $this->hasMany(Refund::class); }
+public function payoutEntries(): HasMany { return $this->hasMany(PayoutLedgerEntry::class); }
+
+public function recomputeTotalsAfterRefund(): void
+{
+    $refundedMinor = $this->refunds()->where('status', RefundStatus::Processed->value)->sum('amount_minor');
+    if ($refundedMinor >= $this->total_minor) {
+        $this->status = OrderStatus::Refunded;
+    } elseif ($refundedMinor > 0) {
+        $this->status = OrderStatus::PartiallyRefunded;
+    }
+    $this->save();
+}
+```
+
+- [ ] **Step 4: OrderItem + OrderItemAssignment**
+
+OrderItem fillable includes `price_tier_id`. Relations: order, ticketType, priceTier, assignments (HasMany), tickets.
+
+OrderItemAssignment fillable: order_item_id, seat_index, holder_user_id, holder_name, holder_email, holder_metadata. Cast holder_metadata→array.
+
+- [ ] **Step 5: Ticket**
+
+Casts: `status` → TicketStatus, `checked_in_at`/`transferred_at` → datetime, `metadata` → array.
+Fillable: holder_id, holder_name, holder_email, status, qr_token, etc.
+Relations: orderItem, ticketType, event, holder (config user model), transferredFrom (config user model), addOnPurchases, transferFeeOrder.
+Methods:
+```php
+public function isCheckedIn(): bool { return $this->status === TicketStatus::CheckedIn; }
+public function transferable(): bool
+{
+    if (! $this->ticketType->transferable) return false;
+    if ($this->ticketType->transfer_deadline_hours_before_event !== null) {
+        $cutoff = $this->event->starts_at->copy()->subHours($this->ticketType->transfer_deadline_hours_before_event);
+        if (now()->greaterThanOrEqualTo($cutoff)) return false;
+    }
+    return true;
+}
+```
+
+- [ ] **Step 6: TicketAddOn + TicketAddOnPurchase**
+
+Translatable name + description on TicketAddOn. Cast status → AddOnPurchaseStatus on TicketAddOnPurchase.
+
+- [ ] **Step 7: ReferralLink**
+
+Fillable: event_id, organizer_id, code, landing_path, commission_basis_points, max_uses, uses_count, expires_at, active. Cast expires_at→datetime, active→bool.
+
+- [ ] **Step 8: DiscountCode + DiscountCodeUsage**
+
+DiscountCode casts: kind → DiscountKind, applies_to → DiscountScope, application_scope → DiscountApplicationScope, starts_at/expires_at → datetime, active → bool.
+
+Methods:
+```php
+public function isActive(?Carbon $at = null): bool
+{
+    $when = $at ?? now();
+    if (! $this->active) return false;
+    if ($this->starts_at && $when->lt($this->starts_at)) return false;
+    if ($this->expires_at && $when->gt($this->expires_at)) return false;
+    if ($this->max_uses_total && $this->uses_count >= $this->max_uses_total) return false;
+    return true;
+}
+
+public function usedByUserCount(Model $user): int
+{
+    return $this->usages()->where('user_id', $user->getKey())->count();
+}
+
+public function appliesToEvent(Event $event): bool
+{
+    if ($this->applies_to === DiscountScope::Global) return true;
+    return $this->events()->where('events_events.id', $event->id)->exists();
+}
+```
+
+Relations: events() BelongsToMany via `events_discount_code_event`, usages() HasMany DiscountCodeUsage.
+
+- [ ] **Step 9: Run + commit**
+
+```bash
+vendor/bin/pint
+vendor/bin/phpstan analyse
+vendor/bin/pest tests/Feature/Ticketing tests/Unit/Ticketing
+git add src/Ticketing database/factories/Ticketing tests
+git commit -m "feat(events): add Ticketing models, factories, basic methods"
+```
+
+Feature tests per model (CRUD + relations + simple methods). At least 10 new tests.
+
+---
+
+## Task 8: Attendance + Eligibility models + factories
+
+**Files:** under `src/Attendance/Models/`, `src/Eligibility/Models/`, factories under same trees.
+
+- [ ] **Step 1: Attendee**
+
+Casts status → AttendeeStatus, profile → array.
+Fillable: event_id, ticket_id, user_id, status, profile.
+Relations: event, ticket, user (config), responses (HasMany AttendanceResponse), checkIns (HasMany SessionCheckIn).
+
+Method:
+```php
+public function listVisibility(): AttendeeListVisibility
+{
+    $eventLevel = $this->event->attendee_list_visibility;
+    $selfLevel = ($this->profile['list_visibility'] ?? 'public') === 'private'
+        ? AttendeeListVisibility::Private
+        : AttendeeListVisibility::Public;
+
+    // Most restrictive wins; ordered Private(0) < OrganizerOnly(1) < AttendeesOnly(2) < Public(3)
+    return $eventLevel->isMoreRestrictiveThan($selfLevel) ? $eventLevel : $selfLevel;
+}
+```
+
+Add helper on enum:
+```php
+enum AttendeeListVisibility: string {
+    // ... cases
+    public function rank(): int { return match($this) {
+        self::Private => 0, self::OrganizerOnly => 1, self::AttendeesOnly => 2, self::Public => 3,
+    }; }
+    public function isMoreRestrictiveThan(self $other): bool { return $this->rank() < $other->rank(); }
+}
+```
+
+- [ ] **Step 2: Application**
+
+Cast status → ApplicationStatus, submitted_at/decided_at → datetime. Fillable: event_id, ticket_type_id, applicant_id, status, decision_note, reservation_order_id, metadata.
+Relations: event, ticketType, applicant (user), reservationOrder (Order), requirementChecks (HasMany RequirementCheck).
+
+- [ ] **Step 3: AttendanceForm + AttendanceResponse**
+
+AttendanceForm fillable: event_id, name, schema. Cast schema→array. Method `validate(array $answers): array<string,string>` returning errors.
+
+AttendanceResponse fillable: attendee_id, attendance_form_id, answers. Cast answers→array.
+
+- [ ] **Step 4: Announcement + AnnouncementRecipient**
+
+Announcement: cast audience → AnnouncementAudience, audience_filter → array, scheduled_for/sent_at → datetime.
+Relations: event, author (user), recipients (HasMany), attendees (HasManyThrough).
+
+AnnouncementRecipient: cast status → AnnouncementRecipientStatus, sent_at/opened_at → datetime.
+
+- [ ] **Step 5: Eligibility models**
+
+Requirement: cast type → RequirementType, payload → array, strict → bool. Belongs to event OR ticketType (one of two).
+
+RequirementCheck: cast status → CheckStatus, result → array. Belongs to attendee OR application (one of two), and requirement.
+
+DocumentUpload: HasMedia (Spatie). Fillable: attendee_id, requirement_id, kind, filename, mime_type, byte_size, metadata.
+
+DocumentVerification: cast status → VerificationStatus, decided_at → datetime. Belongs to documentUpload.
+
+- [ ] **Step 6: Run + commit**
+
+```bash
+vendor/bin/pint
+vendor/bin/phpstan analyse
+vendor/bin/pest tests/Feature/Attendance tests/Feature/Eligibility
+git add src/Attendance src/Eligibility database/factories tests
+git commit -m "feat(events): add Attendance + Eligibility models with relations"
+```
+
+---
+
+## Task 9: Flow models + factories
+
+**Files:** under `src/Flow/Models/`.
+
+- [ ] **Step 1: SaleQueueEntry**
+
+Cast status → QueueStatus, joined_at/released_at/expires_at/last_heartbeat_at → datetime. Fillable: event_id, user_id, joined_at, position, last_heartbeat_at, status.
+
+- [ ] **Step 2: WaitlistEntry**
+
+Cast status → WaitlistStatus, offered_at/claim_expires_at → datetime.
+
+- [ ] **Step 3: Refund**
+
+Cast status → RefundStatus, reason → RefundReason, processed_at → datetime, metadata → array. Relations: order, ticket, requester (user), processedBy (user).
+
+- [ ] **Step 4: Sponsor + SponsorTier + SponsorCompTicket**
+
+SponsorTier: translatable name (not declared — keep flat string for sponsor tier names; spec §5.x says `name (string)` so no translation). Fillable per spec.
+
+Sponsor: HasMedia for logo. Cast status → SponsorStatus.
+
+SponsorCompTicket: fillable sponsor_id, ticket_id, issued_at.
+
+- [ ] **Step 5: PayoutLedgerEntry**
+
+Table name = `events_payout_ledger`. Cast status → PayoutStatus, paid_out_at → datetime.
+
+- [ ] **Step 6: CheckInAttempt + AuditLogEntry**
+
+CheckInAttempt: cast occurred_at → datetime; succeeded → bool. Fillable: ticket_id, scanner_user_id, nonce, ip, user_agent, succeeded, failure_reason, occurred_at.
+
+AuditLogEntry: table `events_audit_log`. Cast changes/context → array, occurred_at → datetime. Fillable: event_id, actor_id, actor_type, action, subject_type, subject_id, changes, context, occurred_at.
+
+- [ ] **Step 7: Run + commit**
+
+```bash
+vendor/bin/pint && vendor/bin/phpstan analyse && vendor/bin/pest
+git add src/Flow database/factories tests
+git commit -m "feat(events): add Flow models (queue, waitlist, refund, sponsor, payout, audit log)"
+```
+
+---
+
+## Task 10: Contracts + value objects
+
+**Files:** under `src/{Catalog,Ticketing,Eligibility,Flow}/Contracts/`, `src/Contracts/`, `src/Eligibility/Engine/`.
+
+- [ ] **Step 1: Eligibility contracts**
+
+`src/Eligibility/Contracts/RequirementEvaluator.php`:
+```php
+namespace Kurt\Modules\Events\Eligibility\Contracts;
+
+use Illuminate\Database\Eloquent\Model;
+use Kurt\Modules\Events\Eligibility\Engine\CheckResult;
+
+interface RequirementEvaluator
+{
+    /** @param array<string, mixed> $payload */
+    public function evaluate(Model $attendee, array $payload, array $context = []): CheckResult;
+}
+```
+
+`src/Eligibility/Contracts/DocumentVerifier.php` — optional, FQCN binding.
+`src/Eligibility/Contracts/GroupResolver.php` — `groupsFor(Model $user): array`.
+
+- [ ] **Step 2: Engine value objects**
+
+`src/Eligibility/Engine/CheckResult.php`:
+```php
+namespace Kurt\Modules\Events\Eligibility\Engine;
+
+use Kurt\Modules\Events\Eligibility\Enums\CheckStatus;
+
+final readonly class CheckResult
+{
+    public function __construct(
+        public CheckStatus $status,
+        public ?string $message = null,
+        public array $data = [],
+    ) {}
+
+    public static function pass(array $data = []): self { return new self(CheckStatus::Passed, null, $data); }
+    public static function fail(string $message, array $data = []): self { return new self(CheckStatus::Failed, $message, $data); }
+    public static function pending(string $message = 'Awaiting review'): self { return new self(CheckStatus::Pending, $message); }
+}
+```
+
+`src/Eligibility/Engine/EvaluationOutcome.php` — readonly with `bool $allPassed`, `bool $anyStrictFailed`, `array<int, RequirementCheck> $checks`.
+
+- [ ] **Step 3: Flow contracts**
+
+`src/Flow/Contracts/QueueChallengeProvider.php` per spec §13a.
+
+- [ ] **Step 4: Catalog contracts**
+
+`src/Catalog/Contracts/EventChatBridge.php` per spec §13a.
+
+- [ ] **Step 5: Person-side contracts + traits**
+
+`src/Contracts/EventOrganizer.php`:
+```php
+interface EventOrganizer
+{
+    public function getKey(): int|string;
+    public function getEventOrganizerDisplayName(): string;
+}
+```
+
+`src/Contracts/EventAttendee.php`:
+```php
+interface EventAttendee
+{
+    public function getKey(): int|string;
+    public function getEventAttendeeDisplayName(): string;
+    public function getEventAttendeeEmail(): string;
+}
+```
+
+`src/Concerns/IsEventOrganizer.php` — relations `eventsOrganized(): BelongsToMany`, `eventOrders(): HasMany`, etc.
+
+`src/Concerns/IsEventAttendee.php` — `eventTickets(): HasMany`, `eventApplications(): HasMany`, `eventAttendances(): HasMany`.
+
+- [ ] **Step 6: Run + commit**
+
+```bash
+vendor/bin/pint && vendor/bin/phpstan analyse
+git add src/Eligibility/Contracts src/Eligibility/Engine src/Flow/Contracts src/Catalog/Contracts src/Contracts src/Concerns
+git commit -m "feat(events): add contracts + engine value objects"
+```
+
+---
+
+## Task 11: Default requirement evaluators
+
+**Files:** `src/Eligibility/Evaluators/{AgeMinEvaluator,AgeMaxEvaluator,DocumentEvaluator,GroupMembershipEvaluator,GenderEvaluator,FreeFormEvaluator,CustomRuleEvaluator}.php`.
+
+- [ ] **Step 1: AgeMinEvaluator**
+
+Strict TDD. Test:
+```php
+it('passes when attendee is at least min age', function () {
+    $event = Event::factory()->create();
+    $ticket = Ticket::factory()->forEvent($event)->create();
+    $attendee = Attendee::factory()->create([
+        'event_id' => $event->id, 'ticket_id' => $ticket->id,
+        'profile' => ['date_of_birth' => now()->subYears(20)->toDateString()],
+    ]);
+    $result = (new AgeMinEvaluator())->evaluate($attendee, ['min' => 18]);
+    expect($result->status)->toBe(CheckStatus::Passed);
+});
+
+it('fails when attendee is younger than min age', function () {
+    /* analogous, age 16 vs min 18, expect Failed */
+});
+
+it('returns pending when DOB missing', function () { /* expect Pending with message */ });
+```
+
+Implementation:
+```php
+final class AgeMinEvaluator implements RequirementEvaluator
+{
+    public function evaluate(Model $attendee, array $payload, array $context = []): CheckResult
+    {
+        $dob = $attendee->profile['date_of_birth'] ?? null;
+        if (! is_string($dob)) {
+            return CheckResult::pending('Date of birth not provided');
+        }
+        $age = Carbon::parse($dob)->age;
+        $min = (int) ($payload['min'] ?? 0);
+        return $age >= $min
+            ? CheckResult::pass(['age' => $age])
+            : CheckResult::fail("Minimum age is {$min}", ['age' => $age]);
+    }
+}
+```
+
+- [ ] **Step 2: AgeMaxEvaluator**
+
+Symmetric.
+
+- [ ] **Step 3: DocumentEvaluator**
+
+Returns `pending` until a `DocumentVerification` exists with `status=verified`. Looks up via `DocumentUpload` for `(attendee, requirement)`.
+
+```php
+public function evaluate(Model $attendee, array $payload, array $context = []): CheckResult
+{
+    $requirementId = $context['requirement_id'] ?? null;
+    if (! $requirementId) return CheckResult::pending('Awaiting upload');
+    $upload = DocumentUpload::query()->where('attendee_id', $attendee->id)->where('requirement_id', $requirementId)->latest()->first();
+    if (! $upload) return CheckResult::pending('No document uploaded');
+    $verification = $upload->verifications()->latest()->first();
+    if (! $verification || $verification->status === VerificationStatus::Pending) return CheckResult::pending('Awaiting review');
+    return $verification->status === VerificationStatus::Verified
+        ? CheckResult::pass(['document_upload_id' => $upload->id])
+        : CheckResult::fail('Document rejected', ['document_upload_id' => $upload->id]);
+}
+```
+
+- [ ] **Step 4: GroupMembershipEvaluator**
+
+Uses bound `GroupResolver`:
+```php
+$resolverClass = config('events.requirements.group_resolver');
+if (! $resolverClass) return CheckResult::pending('No group resolver configured');
+$resolver = app($resolverClass);
+$userGroups = $resolver->groupsFor($attendee->user);
+$required = (array) ($payload['group'] ?? []);
+$matched = array_intersect($userGroups, is_array($required) ? $required : [$required]);
+return ! empty($matched)
+    ? CheckResult::pass(['matched_groups' => array_values($matched)])
+    : CheckResult::fail('Not a member of required group');
+```
+
+- [ ] **Step 5: GenderEvaluator**
+
+Reads `attendee.profile.gender`. Passes when in `payload.allowed` array.
+
+- [ ] **Step 6: FreeFormEvaluator**
+
+Always returns `CheckResult::pending('Awaiting reviewer')`. Manual organizer review flips the check status outside the engine.
+
+- [ ] **Step 7: CustomRuleEvaluator**
+
+```php
+public function evaluate(Model $attendee, array $payload, array $context = []): CheckResult
+{
+    $fqcn = $payload['evaluator'] ?? null;
+    if (! $fqcn || ! class_exists($fqcn)) return CheckResult::fail('Invalid custom evaluator FQCN');
+    $impl = app($fqcn);
+    if (! $impl instanceof RequirementEvaluator) return CheckResult::fail('Class does not implement RequirementEvaluator');
+    return $impl->evaluate($attendee, $payload['config'] ?? [], $context);
+}
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+vendor/bin/pint && vendor/bin/phpstan analyse && vendor/bin/pest tests/Feature/Eligibility/Evaluators
+git add src/Eligibility/Evaluators tests/Feature/Eligibility/Evaluators
+git commit -m "feat(events): add default requirement evaluators (age, doc, group, gender, free-form, custom)"
+```
+
+---
+
+## Task 12: RequirementEngine
+
+**Files:** `src/Eligibility/Engine/RequirementEngine.php`, `tests/Feature/Eligibility/RequirementEngineTest.php`.
+
+- [ ] **Step 1: Failing test**
+
+```php
+it('evaluates all requirements attached to a ticket type and persists checks', function () {
+    config()->set('events.requirements.evaluators.age_min', AgeMinEvaluator::class);
+
+    $event = Event::factory()->create();
+    $type = TicketType::factory()->forEvent($event)->create();
+    Requirement::factory()->forTicketType($type)->create([
+        'type' => RequirementType::AgeMin, 'payload' => ['min' => 18], 'strict' => true,
+    ]);
+
+    $attendee = Attendee::factory()->forEvent($event)->create([
+        'profile' => ['date_of_birth' => now()->subYears(25)->toDateString()],
+    ]);
+
+    $engine = app(RequirementEngine::class);
+    $outcome = $engine->evaluateFor($attendee, $type);
+
+    expect($outcome->allPassed)->toBeTrue();
+    expect($outcome->anyStrictFailed)->toBeFalse();
+    expect(RequirementCheck::query()->where('attendee_id', $attendee->id)->count())->toBe(1);
+});
+
+it('flags strict failures and persists Failed status', function () { /* age 16 vs min 18, strict=true */ });
+```
+
+- [ ] **Step 2: Implementation**
+
+```php
+final class RequirementEngine
+{
+    public function __construct(private readonly Container $container, private readonly Repository $config) {}
+
+    public function evaluateFor(Attendee $attendee, TicketType $ticketType): EvaluationOutcome
+    {
+        $requirements = Requirement::query()
+            ->where(fn ($q) => $q->where('event_id', $ticketType->event_id)->orWhere('ticket_type_id', $ticketType->id))
+            ->get();
+
+        $checks = [];
+        $allPassed = true;
+        $anyStrictFailed = false;
+
+        foreach ($requirements as $requirement) {
+            $evaluatorClass = $this->config->get("events.requirements.evaluators.{$requirement->type->value}");
+            if (! $evaluatorClass) continue;
+
+            $evaluator = $this->container->make($evaluatorClass);
+            $result = $evaluator->evaluate($attendee, $requirement->payload ?? [], ['requirement_id' => $requirement->id]);
+
+            $check = RequirementCheck::query()->updateOrCreate(
+                ['attendee_id' => $attendee->id, 'requirement_id' => $requirement->id],
+                ['status' => $result->status, 'result' => array_merge($result->data, ['message' => $result->message])],
+            );
+
+            $checks[] = $check;
+            if ($result->status !== CheckStatus::Passed) $allPassed = false;
+            if ($result->status === CheckStatus::Failed && $requirement->strict) $anyStrictFailed = true;
+        }
+
+        return new EvaluationOutcome($allPassed, $anyStrictFailed, $checks);
+    }
+}
+```
+
+- [ ] **Step 3: Run + commit**
+
+```bash
+vendor/bin/pest tests/Feature/Eligibility/RequirementEngineTest.php
+git add src/Eligibility/Engine/RequirementEngine.php tests
+git commit -m "feat(events): add RequirementEngine"
+```
+
+---
+
+## Task 13: Pricing engine + discount codes
+
+**Files:** `src/Ticketing/Support/{PriceCalculator,PriceBreakdown,DiscountCodeNotApplicable}.php`, tests under `tests/Feature/Ticketing/PriceCalculatorTest.php`.
+
+- [ ] **Step 1: PriceBreakdown value object**
+
+```php
+final readonly class PriceBreakdown
+{
+    public function __construct(
+        public int $subtotalMinor,
+        public int $discountMinor,
+        public int $totalMinor,
+        public string $currency,
+    ) {}
+}
+```
+
+- [ ] **Step 2: DiscountCodeNotApplicable typed exception**
+
+```php
+final class DiscountCodeNotApplicable extends RuntimeException
+{
+    public static function code(string $reason): self { return new self($reason); }
+}
+```
+
+- [ ] **Step 3: PriceCalculator tests**
+
+```php
+it('applies a percent discount', function () {
+    $code = DiscountCode::factory()->create([
+        'kind' => DiscountKind::Percent, 'amount_minor' => 1000, // 10%
+        'applies_to' => DiscountScope::Global, 'active' => true,
+    ]);
+    $type = TicketType::factory()->create(['price_minor' => 10_000, 'currency' => 'USD']);
+
+    $draftOrder = $this->draftOrderWith($type, quantity: 2);
+    $breakdown = (new PriceCalculator())->apply($draftOrder, $code);
+
+    expect($breakdown->subtotalMinor)->toBe(20_000);
+    expect($breakdown->discountMinor)->toBe(2_000);
+    expect($breakdown->totalMinor)->toBe(18_000);
+});
+
+it('rejects code when currency mismatches', function () { /* expect DiscountCodeNotApplicable */ });
+it('rejects expired code', function () { /* … */ });
+it('rejects when per-user limit reached', function () { /* … */ });
+it('applies flat-amount per-ticket scope', function () { /* … */ });
+it('clamps discount to subtotal so total >= 0', function () { /* … */ });
+```
+
+- [ ] **Step 4: PriceCalculator implementation**
+
+```php
+final class PriceCalculator
+{
+    public function apply(DraftOrder $draft, ?DiscountCode $code = null): PriceBreakdown
+    {
+        $subtotal = $draft->lineTotals()->sum();
+        $currency = $draft->currency;
+        $discount = 0;
+
+        if ($code !== null) {
+            $this->guardApplicable($code, $draft);
+            $discount = match ($code->kind) {
+                DiscountKind::Percent => intdiv($subtotal * $code->amount_minor, 10_000),
+                DiscountKind::FlatAmount => $code->application_scope === DiscountApplicationScope::Order
+                    ? $code->amount_minor
+                    : $code->amount_minor * $draft->totalQuantity(),
+            };
+            $discount = min($discount, $subtotal);
+        }
+
+        $total = max(0, $subtotal - $discount);
+
+        return new PriceBreakdown($subtotal, $discount, $total, $currency);
+    }
+
+    private function guardApplicable(DiscountCode $code, DraftOrder $draft): void
+    {
+        if (! $code->isActive()) throw DiscountCodeNotApplicable::code('inactive');
+        if ($code->kind === DiscountKind::FlatAmount && $code->currency !== $draft->currency) {
+            throw DiscountCodeNotApplicable::code('currency_mismatch');
+        }
+        if ($code->max_uses_per_user && $code->usedByUserCount($draft->buyer) >= $code->max_uses_per_user) {
+            throw DiscountCodeNotApplicable::code('per_user_limit');
+        }
+        if (! $code->appliesToEvent($draft->event)) throw DiscountCodeNotApplicable::code('scope_mismatch');
+    }
+}
+```
+
+`DraftOrder` is a small value object holding pending OrderItems + event + buyer + currency. Define alongside.
+
+- [ ] **Step 5: Commit**
+
+```bash
+vendor/bin/pest tests/Feature/Ticketing/PriceCalculatorTest.php
+git add src/Ticketing/Support tests
+git commit -m "feat(events): add PriceCalculator + DiscountCodeNotApplicable"
+```
+
+---
+
+## Task 14: QR token signer + check-in helpers
+
+**Files:** `src/Ticketing/Support/QrTokenSigner.php`, `src/Ticketing/Support/TicketCheckIn.php`, tests.
+
+- [ ] **Step 1: QrTokenSigner**
+
+```php
+final class QrTokenSigner
+{
+    public function __construct(private readonly string $appKey) {}
+
+    public function sign(int $ticketId, int $eventId, ?int $issuedAt = null): string
+    {
+        $payload = json_encode([
+            'ticket_id' => $ticketId, 'event_id' => $eventId,
+            'issued_at' => $issuedAt ?? time(),
+            'nonce' => Str::random(16),
+        ]);
+        $b64 = rtrim(strtr(base64_encode($payload), '+/', '-_'), '=');
+        $sig = hash_hmac('sha256', $payload, $this->appKey);
+        return "{$b64}.{$sig}";
+    }
+
+    /** @return array{ticket_id:int,event_id:int,issued_at:int,nonce:string} */
+    public function verify(string $token): array
+    {
+        [$b64, $sig] = explode('.', $token, 2) + [null, null];
+        if ($b64 === null || $sig === null) throw new InvalidArgumentException('Malformed token');
+        $payload = base64_decode(strtr($b64, '-_', '+/'));
+        if (! hash_equals(hash_hmac('sha256', $payload, $this->appKey), $sig)) {
+            throw new InvalidArgumentException('Signature mismatch');
+        }
+        $data = json_decode($payload, true, flags: JSON_THROW_ON_ERROR);
+        return $data;
+    }
+}
+```
+
+Bind in service provider with `config('app.key')` as the constructor arg.
+
+- [ ] **Step 2: Tests**
+
+`tests/Unit/Ticketing/QrTokenSignerTest.php` — round-trip; signature mismatch throws; tampering caught.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Ticketing/Support/QrTokenSigner.php tests/Unit/Ticketing/QrTokenSignerTest.php
+git commit -m "feat(events): add QrTokenSigner with HMAC signature"
+```
+
+---
+
+## Task 15: Transfer engine + observer-driven counter denormalisation
+
+**Files:** `src/Ticketing/Support/TransferEngine.php`, `src/Ticketing/Observers/{TicketObserver,OrderObserver}.php`.
+
+- [ ] **Step 1: TransferEngine** — encapsulates spec §11.3 rules.
+
+```php
+final class TransferEngine
+{
+    public function attemptTransfer(Ticket $ticket, Model $newHolder): Ticket
+    {
+        if (! $ticket->ticketType->transferable) throw new TransferNotAllowed('Type not transferable');
+        if (! $ticket->transferable()) throw new TransferNotAllowed('Deadline passed');
+
+        $fee = $ticket->ticketType->transfer_fee_minor;
+        if ($fee !== null && $fee > 0) {
+            // Create fee Order in pending; do NOT swap holder yet.
+            $feeOrder = $this->createFeeOrder($ticket, $newHolder, $fee, $ticket->ticketType->transfer_fee_currency);
+            $ticket->forceFill(['transfer_fee_order_id' => $feeOrder->id])->save();
+            TicketTransferRequested::dispatch($ticket, $newHolder);
+            return $ticket;
+        }
+
+        // Free transfer: complete immediately.
+        return $this->completeTransfer($ticket, $newHolder);
+    }
+
+    public function completeTransfer(Ticket $ticket, Model $newHolder): Ticket
+    {
+        $oldHolderId = $ticket->holder_id;
+        $ticket->forceFill([
+            'holder_id' => $newHolder->getKey(),
+            'holder_name' => $newHolder->name ?? $newHolder->email,
+            'holder_email' => $newHolder->email,
+            'transferred_from' => $oldHolderId,
+            'transferred_at' => now(),
+        ])->save();
+
+        TicketTransferred::dispatch($ticket, $oldHolderId, $newHolder);
+        return $ticket;
+    }
+
+    private function createFeeOrder(Ticket $ticket, Model $newHolder, int $amountMinor, string $currency): Order
+    {
+        return Order::create([
+            'event_id' => $ticket->event_id,
+            'user_id' => $newHolder->getKey(),
+            'status' => OrderStatus::Pending,
+            'subtotal_minor' => $amountMinor, 'discount_minor' => 0, 'tax_minor' => 0, 'total_minor' => $amountMinor,
+            'currency' => $currency,
+            'metadata' => ['transfer_for_ticket_id' => $ticket->id],
+        ]);
+    }
+}
+```
+
+- [ ] **Step 2: OrderObserver** — completes fee transfers, fires payout accrual.
+
+```php
+final class OrderObserver
+{
+    public function __construct(private readonly TransferEngine $transferEngine, private readonly PayoutAccruer $payoutAccruer) {}
+
+    public function updated(Order $order): void
+    {
+        if (! $order->wasChanged('status')) return;
+
+        if ($order->status === OrderStatus::Paid) {
+            // Check if this is a transfer fee order: complete the transfer.
+            $ticketId = $order->metadata['transfer_for_ticket_id'] ?? null;
+            if ($ticketId) {
+                $ticket = Ticket::find($ticketId);
+                if ($ticket) {
+                    $newHolder = $order->buyer;
+                    $this->transferEngine->completeTransfer($ticket, $newHolder);
+                }
+            }
+
+            if (config('events.payouts.auto_accrue_on_order_paid')) {
+                $this->payoutAccruer->accrueFor($order);
+            }
+
+            OrderPaid::dispatch($order);
+        }
+    }
+}
+```
+
+- [ ] **Step 3: TicketObserver** — increments `tickets_sold_count` on event when created, decrements on cancel/refund. Also denormalises holder fields from `OrderItemAssignment` when one is linked.
+
+- [ ] **Step 4: Tests**
+
+Free transfer happy path; transfer with fee creates pending order; pending order paid → holder flips.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Ticketing/Support/TransferEngine.php src/Ticketing/Observers tests
+git commit -m "feat(events): add TransferEngine + Order/Ticket observers"
+```
+
+---
+
+## Task 16: PayoutAccruer + audit log writer + sponsor coordinator
+
+**Files:** `src/Flow/Support/{PayoutAccruer,AuditLogWriter}.php`, `src/Flow/Support/SponsorCoordinator.php`.
+
+- [ ] **Step 1: PayoutAccruer**
+
+```php
+final class PayoutAccruer
+{
+    public function accrueFor(Order $order): void
+    {
+        $organizers = EventOrganizer::query()->where('event_id', $order->event_id)->whereNotNull('commission_basis_points')->get();
+        foreach ($organizers as $organizer) {
+            $amount = intdiv($order->total_minor * $organizer->commission_basis_points, 10_000);
+            PayoutLedgerEntry::create([
+                'order_id' => $order->id,
+                'organizer_user_id' => $organizer->user_id,
+                'share_basis_points' => $organizer->commission_basis_points,
+                'amount_minor' => $amount,
+                'currency' => $order->currency,
+                'status' => PayoutStatus::Accrued,
+            ]);
+        }
+    }
+}
+```
+
+- [ ] **Step 2: AuditLogWriter**
+
+```php
+final class AuditLogWriter
+{
+    public function write(
+        string $action,
+        ?Model $subject = null,
+        ?Model $actor = null,
+        ?int $eventId = null,
+        ?array $changes = null,
+    ): void {
+        if (! config('events.audit.enabled')) return;
+
+        AuditLogEntry::create([
+            'event_id' => $eventId,
+            'actor_id' => $actor?->getKey(),
+            'actor_type' => $actor ? $this->classifyActor($actor) : 'system',
+            'action' => $action,
+            'subject_type' => $subject ? $subject::class : null,
+            'subject_id' => $subject?->getKey(),
+            'changes' => $changes,
+            'context' => $this->captureContext(),
+            'occurred_at' => now(),
+        ]);
+    }
+
+    private function captureContext(): ?array
+    {
+        if (! config('events.audit.capture_context')) return null;
+        $req = request();
+        return ['ip' => $req?->ip(), 'user_agent' => (string) $req?->userAgent()];
+    }
+
+    private function classifyActor(Model $actor): string { /* … */ return 'user'; }
+}
+```
+
+- [ ] **Step 3: SponsorCoordinator**
+
+```php
+final class SponsorCoordinator
+{
+    public function purchaseSponsorship(Event $event, SponsorTier $tier, Model $contactUser, array $data): Sponsor
+    {
+        return DB::transaction(function () use ($event, $tier, $contactUser, $data) {
+            // B2B billing order for the sponsorship itself
+            $order = Order::create([
+                'event_id' => $event->id, 'user_id' => $contactUser->getKey(),
+                'status' => OrderStatus::Pending,
+                'subtotal_minor' => $tier->price_minor, 'discount_minor' => 0, 'tax_minor' => 0,
+                'total_minor' => $tier->price_minor, 'currency' => $tier->currency,
+                'metadata' => ['sponsorship_for_tier_id' => $tier->id],
+            ]);
+            $sponsor = Sponsor::create([
+                'event_id' => $event->id, 'sponsor_tier_id' => $tier->id,
+                'name' => $data['name'], 'contact_user_id' => $contactUser->getKey(),
+                'logo_path' => $data['logo_path'] ?? null,
+                'website_url' => $data['website_url'] ?? null,
+                'blurb' => $data['blurb'] ?? null,
+                'status' => SponsorStatus::Pending,
+                'order_id' => $order->id,
+            ]);
+            return $sponsor;
+        });
+    }
+
+    public function issueCompTicket(Sponsor $sponsor, Model $holder, array $assignmentData): Ticket
+    {
+        $tier = $sponsor->tier;
+        $issuedCount = SponsorCompTicket::query()->where('sponsor_id', $sponsor->id)->count();
+        if ($tier->comp_ticket_quota === 0 || $issuedCount >= $tier->comp_ticket_quota) {
+            throw new RuntimeException('Comp quota exhausted');
+        }
+        if ($tier->comp_ticket_type_id === null) {
+            throw new RuntimeException('Tier has no comp ticket type configured');
+        }
+
+        $ticket = Ticket::create([
+            'order_item_id' => null, // comp tickets bypass order_items; flag via metadata
+            'ticket_type_id' => $tier->comp_ticket_type_id,
+            'event_id' => $sponsor->event_id,
+            'holder_id' => $holder->getKey(),
+            'holder_name' => $assignmentData['name'] ?? ($holder->name ?? 'Sponsor Comp'),
+            'holder_email' => $assignmentData['email'] ?? ($holder->email ?? ''),
+            'status' => TicketStatus::Issued,
+            'qr_token' => app(QrTokenSigner::class)->sign(/* will be filled after persist */ 0, $sponsor->event_id),
+            'metadata' => ['comp_for_sponsor_id' => $sponsor->id],
+        ]);
+
+        SponsorCompTicket::create([
+            'sponsor_id' => $sponsor->id,
+            'ticket_id' => $ticket->id,
+            'issued_at' => now(),
+        ]);
+
+        TicketIssued::dispatch($ticket);
+        return $ticket;
+    }
+}
+```
+
+The `OrderObserver` (Task 15) detects sponsorship orders by `metadata.sponsorship_for_tier_id` and flips `Sponsor.status` to `Active` when the order is paid.
+
+- [ ] **Step 4: Tests**
+
+PayoutAccruer: paid order with 2 organizers (60/40 split) → 2 ledger rows summing to order total.
+AuditLogWriter: writes row with captured ip; honours `audit.enabled=false`.
+SponsorCoordinator: purchase creates pending order + pending sponsor; paying flips both to Paid + Active; comp-ticket issuance respects quota.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Flow/Support/PayoutAccruer.php src/Flow/Support/AuditLogWriter.php src/Flow/Support/SponsorCoordinator.php tests
+git commit -m "feat(events): add PayoutAccruer + AuditLogWriter + SponsorCoordinator"
+```
+
+---
+
+## Task 17: Sale queue mechanics
+
+**Files:** `src/Flow/Support/{QueueReleaser,QueuePruner}.php`, `src/Flow/Events/{QueueJoined,QueueReleased,QueueExpired}.php`, `src/Flow/Exceptions/QueueChallengeFailed.php`.
+
+- [ ] **Step 1: QueueReleaser**
+
+```php
+final class QueueReleaser
+{
+    public function releaseFor(Event $event): int
+    {
+        $concurrency = (int) config('events.queue.active_concurrency');
+        $windowSeconds = (int) config('events.queue.active_window_seconds');
+
+        return DB::transaction(function () use ($event, $concurrency, $windowSeconds) {
+            $activeCount = SaleQueueEntry::query()->where('event_id', $event->id)
+                ->where('status', QueueStatus::Active->value)->lockForUpdate()->count();
+            $promote = max(0, $concurrency - $activeCount);
+            if ($promote === 0) return 0;
+
+            $waiting = SaleQueueEntry::query()->where('event_id', $event->id)
+                ->where('status', QueueStatus::Waiting->value)
+                ->orderBy('position')->limit($promote)->lockForUpdate()->get();
+
+            foreach ($waiting as $entry) {
+                $entry->forceFill([
+                    'status' => QueueStatus::Active,
+                    'released_at' => now(),
+                    'expires_at' => now()->addSeconds($windowSeconds),
+                ])->save();
+                QueueReleased::dispatch($entry);
+            }
+            return $waiting->count();
+        });
+    }
+}
+```
+
+- [ ] **Step 2: QueuePruner**
+
+```php
+final class QueuePruner
+{
+    public function pruneFor(Event $event): int
+    {
+        $cutoff = now()->subSeconds((int) config('events.queue.heartbeat_timeout_seconds'));
+        return SaleQueueEntry::query()->where('event_id', $event->id)
+            ->where('status', QueueStatus::Waiting->value)
+            ->where('last_heartbeat_at', '<', $cutoff)
+            ->update(['status' => QueueStatus::Abandoned]);
+    }
+}
+```
+
+- [ ] **Step 3: Anti-bot challenge check**
+
+When `config('events.anti_bot.queue_challenge')` is set, `Events::joinQueue` calls the provider's `verify()`. Failed verify throws `QueueChallengeFailed`.
+
+- [ ] **Step 4: Tests**
+
+Sequential release preserves position order; abandoned heartbeats marked; expired actives free up next promotion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Flow/Support/{QueueReleaser,QueuePruner}.php src/Flow/Events src/Flow/Exceptions tests
+git commit -m "feat(events): add sale queue release + prune mechanics"
+```
+
+---
+
+## Task 18: Waitlist + refund coordinator
+
+**Files:** `src/Flow/Support/{WaitlistPromoter,RefundCoordinator}.php`.
+
+- [ ] **Step 1: WaitlistPromoter**
+
+When a ticket cancels: find next `WaitlistEntry`, set `status=offered + offered_at + claim_expires_at`, dispatch `WaitlistPromoted`.
+
+```php
+final class WaitlistPromoter
+{
+    public function promoteNextFor(TicketType $type): ?WaitlistEntry
+    {
+        $next = WaitlistEntry::query()->where('ticket_type_id', $type->id)
+            ->where('status', WaitlistStatus::Waiting->value)
+            ->orderBy('created_at')->lockForUpdate()->first();
+        if (! $next) return null;
+        $next->forceFill([
+            'status' => WaitlistStatus::Offered,
+            'offered_at' => now(),
+            'claim_expires_at' => now()->addSeconds((int) config('events.waitlist.claim_window_seconds')),
+        ])->save();
+        WaitlistPromoted::dispatch($next);
+        return $next;
+    }
+}
+```
+
+- [ ] **Step 2: RefundCoordinator (with EU consumer-protection window + buyer self-cancel)**
+
+```php
+final class RefundCoordinator
+{
+    public function request(Order|Ticket $target, Model $requester, RefundReason $reason, ?string $note = null, ?int $amountMinor = null): Refund
+    {
+        $order = $target instanceof Ticket ? $target->orderItem->order : $target;
+        $amount = $amountMinor ?? ($target instanceof Ticket ? $target->orderItem->unit_price_minor : $order->total_minor);
+        $refund = Refund::create([
+            'order_id' => $order->id,
+            'ticket_id' => $target instanceof Ticket ? $target->id : null,
+            'amount_minor' => $amount,
+            'currency' => $order->currency,
+            'reason' => $reason,
+            'reason_note' => $note,
+            'status' => RefundStatus::Pending,
+            'requested_by' => $requester->getKey(),
+        ]);
+        RefundRequested::dispatch($refund);
+        return $refund;
+    }
+
+    public function markProcessed(Refund $refund, string $processorReference): void
+    {
+        $refund->forceFill([
+            'status' => RefundStatus::Processed, 'processor_reference' => $processorReference, 'processed_at' => now(),
+        ])->save();
+        $refund->order->recomputeTotalsAfterRefund();
+        RefundProcessed::dispatch($refund);
+    }
+
+    /**
+     * Buyer self-cancellation per spec §16.4.
+     * Honours EU consumer-protection window + per-type self-cancel deadline.
+     */
+    public function cancelOrderByBuyer(Order $order, Model $buyer): Refund
+    {
+        if ($order->user_id !== $buyer->getKey()) {
+            throw new RuntimeException('Not the order buyer');
+        }
+        if ($order->status !== OrderStatus::Paid) {
+            throw new RuntimeException('Only paid orders can be self-cancelled');
+        }
+        if ($order->tickets->some(fn ($t) => $t->status === TicketStatus::CheckedIn)) {
+            throw new RuntimeException('Cannot self-cancel after check-in');
+        }
+
+        $allowedByEu = $this->isInConsumerProtectionWindow($order);
+        $allowedBySelfCancelDeadline = $order->items->every(function (OrderItem $item) {
+            $hours = $item->ticketType->self_cancel_deadline_hours_before_event;
+            if ($hours === null) return false;
+            $cutoff = $item->order->event->starts_at->copy()->subHours($hours);
+            return now()->lt($cutoff);
+        });
+
+        if (! $allowedByEu && ! $allowedBySelfCancelDeadline) {
+            throw new SelfCancellationNotPermitted();
+        }
+
+        $refund = $this->request($order, $buyer, RefundReason::AttendeeRequest, 'Buyer self-cancellation');
+        $refund->forceFill(['metadata' => ['consumer_protection_eligible' => $allowedByEu]])->save();
+        return $refund;
+    }
+
+    private function isInConsumerProtectionWindow(Order $order): bool
+    {
+        $windowDays = (int) config('events.refunds.consumer_protection_window_days');
+        if ($windowDays === 0) return false;
+        if (! $order->paid_at || $order->paid_at->lt(now()->subDays($windowDays))) return false;
+        // any consumer_protection_exempt ticket disqualifies the entire order
+        return $order->items->every(fn ($i) => ! $i->ticketType->consumer_protection_exempt);
+    }
+}
+```
+
+Add typed exception `src/Flow/Exceptions/SelfCancellationNotPermitted.php`:
+```php
+namespace Kurt\Modules\Events\Flow\Exceptions;
+final class SelfCancellationNotPermitted extends \RuntimeException {}
+```
+
+- [ ] **Step 3: Tests**
+
+Waitlist sequential promotion; refund pending → processed → order recompute → status.
+EU consumer-protection window: paid 5 days ago + non-exempt + uncheckedin → `cancelOrderByBuyer` returns Refund with `consumer_protection_eligible=true`. Paid 20 days ago → throws `SelfCancellationNotPermitted`. Per-type deadline passes → throws. Exempt ticket type → throws.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Flow/Support tests
+git commit -m "feat(events): add WaitlistPromoter + RefundCoordinator"
+```
+
+---
+
+## Task 19: AnnouncementDispatcher + reminder scheduling
+
+**Files:** `src/Attendance/Support/AnnouncementDispatcher.php`, `src/Notifications/{EventAnnouncementPosted,EventReminderDue,TicketIssued,…}.php`.
+
+- [ ] **Step 1: AnnouncementDispatcher**
+
+```php
+final class AnnouncementDispatcher
+{
+    public function dispatch(Announcement $announcement): int
+    {
+        $attendees = $this->audienceFor($announcement);
+        $count = 0;
+        foreach ($attendees as $attendee) {
+            $recipient = AnnouncementRecipient::firstOrCreate(
+                ['announcement_id' => $announcement->id, 'attendee_id' => $attendee->id],
+                ['status' => AnnouncementRecipientStatus::Pending],
+            );
+            // Send via Laravel Notification when enabled
+            if (config('events.notifications.enabled')) {
+                $attendee->user?->notify(new EventAnnouncementPosted($announcement, $recipient));
+            }
+            $recipient->forceFill(['status' => AnnouncementRecipientStatus::Sent, 'sent_at' => now()])->save();
+            $count++;
+        }
+        $announcement->forceFill(['sent_at' => now(), 'recipient_count' => $count])->save();
+        AnnouncementSent::dispatch($announcement);
+        return $count;
+    }
+
+    private function audienceFor(Announcement $a): Collection
+    {
+        $query = Attendee::query()->where('event_id', $a->event_id);
+        return match ($a->audience) {
+            AnnouncementAudience::All => $query->get(),
+            AnnouncementAudience::Registered => $query->where('status', AttendeeStatus::Registered->value)->get(),
+            AnnouncementAudience::CheckedIn => $query->where('status', AttendeeStatus::CheckedIn->value)->get(),
+            AnnouncementAudience::ByTicketType => $query->whereHas('ticket', fn ($q) => $q->whereIn('ticket_type_id', $a->audience_filter['ticket_type_ids'] ?? []))->get(),
+            AnnouncementAudience::BySession => $query->whereHas('checkIns', fn ($q) => $q->whereIn('session_id', $a->audience_filter['session_ids'] ?? []))->get(),
+        };
+    }
+}
+```
+
+- [ ] **Step 2: Notification classes**
+
+`EventAnnouncementPosted`, `TicketIssued`, `TicketTransferred`, `EventReminderDue`, `SessionReminderDue`, `ApplicationApproved`, `ApplicationRejected`, `OrderPaid`, `RefundProcessed`, `WaitlistOffer`.
+
+Default blade templates under `resources/views/notifications/*.blade.php` (5–8 lines each, plain text). Reuse `MailMessage`.
+
+- [ ] **Step 3: Tests**
+
+Mail::fake; assertSentTo expected attendees; recipient count denormalised.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Attendance/Support src/Notifications resources/views/notifications tests
+git commit -m "feat(events): add AnnouncementDispatcher + default Notification classes"
+```
+
+---
+
+## Task 20: EventCloner + IcsExporter + templates + GDPR helpers
+
+**Files:** `src/Catalog/Support/{EventCloner,IcsExporter,RecurrenceExpander,TemplateManager}.php`, `src/Flow/Support/{GdprExporter,GdprAnonymizer}.php`.
+
+- [ ] **Step 1: EventCloner**
+
+```php
+final class EventCloner
+{
+    public function clone(Event $source, array $overrides = []): Event
+    {
+        return DB::transaction(function () use ($source, $overrides) {
+            $new = $source->replicate(['slug','tickets_sold_count','attendees_count','applications_pending_count'])
+                ->fill($overrides);
+            $new->status = EventStatus::Draft;
+            $new->save();
+            foreach ($source->sessions as $session) {
+                $new->sessions()->create($session->replicate()->toArray());
+            }
+            foreach ($source->ticketTypes as $type) {
+                $cloneType = $new->ticketTypes()->create($type->replicate()->toArray());
+                foreach ($type->priceTiers as $tier) {
+                    $cloneType->priceTiers()->create($tier->replicate()->toArray());
+                }
+            }
+            // similar for sponsor tiers, add-ons, requirements, attendance forms
+            EventClonedFrom::dispatch($source, $new);
+            return $new;
+        });
+    }
+}
+```
+
+- [ ] **Step 2: IcsExporter**
+
+`src/Catalog/Support/IcsExporter.php`:
+```php
+final class IcsExporter
+{
+    public function forEvent(Event $event): string
+    {
+        $uid = "event-{$event->id}@kurtmodules-events";
+        $now = now()->utc()->format('Ymd\THis\Z');
+        $start = $event->starts_at->copy()->utc()->format('Ymd\THis\Z');
+        $end = $event->ends_at->copy()->utc()->format('Ymd\THis\Z');
+        $title = $event->getTranslation('title', app()->getLocale());
+        $description = strip_tags((string) $event->getTranslation('description', app()->getLocale(), false));
+        $location = $event->location_name ?? $event->location_address ?? '';
+
+        $rrule = '';
+        if (! empty($event->recurrence_rule)) {
+            $rrule = "RRULE:" . $this->buildRrule($event->recurrence_rule) . "\r\n";
+        }
+
+        return implode("\r\n", [
+            'BEGIN:VCALENDAR', 'VERSION:2.0', 'PRODID:-//KurtModules//Events//EN', 'CALSCALE:GREGORIAN',
+            'BEGIN:VEVENT',
+            "UID:{$uid}", "DTSTAMP:{$now}", "DTSTART:{$start}", "DTEND:{$end}",
+            "SUMMARY:" . $this->escape($title),
+            "DESCRIPTION:" . $this->escape($description),
+            "LOCATION:" . $this->escape($location),
+            rtrim($rrule, "\r\n"),
+            'END:VEVENT', 'END:VCALENDAR',
+        ]);
+    }
+
+    private function buildRrule(array $rule): string
+    {
+        $parts = ['FREQ=' . strtoupper((string) ($rule['frequency'] ?? 'WEEKLY'))];
+        if (isset($rule['interval'])) $parts[] = 'INTERVAL=' . $rule['interval'];
+        if (isset($rule['count'])) $parts[] = 'COUNT=' . $rule['count'];
+        if (isset($rule['until'])) $parts[] = 'UNTIL=' . \Carbon\Carbon::parse($rule['until'])->utc()->format('Ymd\THis\Z');
+        if (isset($rule['byDay'])) $parts[] = 'BYDAY=' . implode(',', $rule['byDay']);
+        if (isset($rule['byMonthDay'])) $parts[] = 'BYMONTHDAY=' . implode(',', $rule['byMonthDay']);
+        return implode(';', $parts);
+    }
+
+    private function escape(string $value): string
+    {
+        return str_replace(["\\", "\n", ",", ";"], ["\\\\", "\\n", "\\,", "\\;"], $value);
+    }
+}
+```
+
+`Event::ics()` returns `response($exporter->forEvent($this), 200, ['Content-Type' => 'text/calendar'])`.
+
+Test: ICS string includes `BEGIN:VEVENT` + correct DTSTART; recurring event includes `RRULE:FREQ=WEEKLY;BYDAY=MO,WE`.
+
+- [ ] **Step 3: RecurrenceExpander**
+
+Materialises occurrence Event rows from `recurrence_rule` for the next `events.recurrence.window_days`. Called by `events:generate-occurrences` command.
+
+- [ ] **Step 4: TemplateManager**
+
+```php
+final class TemplateManager
+{
+    public function __construct(private readonly EventCloner $cloner) {}
+
+    public function saveAs(Event $source, Model $owner, string $name, ?string $slug = null, bool $public = false): EventTemplate
+    {
+        return EventTemplate::create([
+            'owner_id' => $owner->getKey(),
+            'slug' => $slug ?? str($name)->slug(),
+            'name' => $name,
+            'is_public' => $public,
+            'payload' => $this->snapshot($source),
+        ]);
+    }
+
+    public function spawn(EventTemplate $template, Model $organizer, array $overrides = []): Event
+    {
+        return DB::transaction(function () use ($template, $organizer, $overrides) {
+            $event = Event::create(array_merge($template->payload['event'], $overrides, [
+                'status' => config('events.publishing.require_approval') ? EventStatus::PendingApproval : EventStatus::Draft,
+            ]));
+            $event->organizers()->create([
+                'user_id' => $organizer->getKey(), 'role' => OrganizerRole::Owner,
+            ]);
+            foreach ($template->payload['sessions'] ?? [] as $session) {
+                $event->sessions()->create($session);
+            }
+            foreach ($template->payload['ticket_types'] ?? [] as $type) {
+                $event->ticketTypes()->create($type);
+            }
+            $template->increment('used_count');
+            EventCreatedFromTemplate::dispatch($event, $template);
+            return $event;
+        });
+    }
+
+    private function snapshot(Event $event): array
+    {
+        return [
+            'event' => $event->only(['title','description','category_id','timezone','attendee_list_visibility']),
+            'sessions' => $event->sessions->map->only(['slug','title','description','starts_at','ends_at','capacity','position'])->all(),
+            'ticket_types' => $event->ticketTypes->map->only([/* all type columns */])->all(),
+            // sponsor_tiers, requirements, add-ons, attendance_forms similarly
+        ];
+    }
+}
+```
+
+- [ ] **Step 5: GdprExporter**
+
+Walks tables; returns structured array per spec §25.5.
+
+- [ ] **Step 6: GdprAnonymizer**
+
+Replaces PII columns with hashes or nulls. Honours `events.gdpr.anonymize_audit_log_actor`.
+
+- [ ] **Step 7: Tests**
+
+Cloned event has independent ticket types + price tiers; no sales data carried; ICS string parses (BEGIN:VEVENT/DTSTART/SUMMARY present); RRULE built from rule JSON; template snapshot+spawn roundtrip; exporter dump contains expected sections; anonymizer replaces holder_name + holder_email + profile.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Catalog/Support src/Flow/Support/GdprExporter.php src/Flow/Support/GdprAnonymizer.php tests
+git commit -m "feat(events): add EventCloner + IcsExporter + RecurrenceExpander + TemplateManager + GDPR helpers"
+```
+
+---
+
+## Task 21: Domain events
+
+**Files:** under `src/Catalog/Events/`, `src/Ticketing/Events/`, `src/Attendance/Events/`, `src/Eligibility/Events/`, `src/Flow/Events/`.
+
+- [ ] **Step 1: Write all event classes**
+
+Each uses `Illuminate\Foundation\Events\Dispatchable`. One file per event listed in spec §14. Single-arg events have one readonly promoted property; multi-arg as needed.
+
+Examples already shown in earlier tasks (`OrderPaid`, `RefundProcessed`, `QueueReleased`, `WaitlistPromoted`, `EventClonedFrom`, `TicketTransferRequested`, `TicketTransferred`, `AnnouncementSent`, etc.).
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/*/Events
+git commit -m "feat(events): add domain events"
+```
+
+---
+
+## Task 22: Policies
+
+**Files:** `src/Policies/{EventPolicy,TicketTypePolicy,OrderPolicy,ApplicationPolicy,RefundPolicy,QueuePolicy,WaitlistPolicy,EventApprovalPolicy}.php`.
+
+Implement gates from spec §18. `canManageEvents` and `canManageEventApprovals` gates check via `app('gate')->allows(...)`.
+
+- [ ] **Step 1: EventPolicy**
+
+```php
+public function view(?Authenticatable $user, Event $event): bool { /* visibility + organizer/staff */ }
+public function update(Authenticatable $user, Event $event): bool { /* organizer with manager+ role OR staff */ }
+public function delete(...): bool { /* same */ }
+public function approveForPublication(Authenticatable $user, Event $event): bool
+{
+    return app('gate')->allows('canManageEventApprovals', $user);
+}
+```
+
+- [ ] **Step 2–7: Remaining policies**
+
+Each follows spec §18.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Policies tests
+git commit -m "feat(events): add policies"
+```
+
+---
+
+## Task 23: Console commands
+
+**Files:** `src/Console/Commands/{ReleaseQueueCommand,PruneQueueCommand,ExpireWaitlistClaimsCommand,GenerateOccurrencesCommand,DispatchRemindersCommand,ExpirePendingOrdersCommand,DispatchAnnouncementsCommand,EnforceRetentionCommand,DemoCommand}.php`.
+
+- [ ] **Step 1: ExpirePendingOrdersCommand**
+
+```php
+protected $signature = 'events:expire-pending-orders';
+public function handle(): int
+{
+    $cutoff = now()->subMinutes((int) config('events.orders.pending_timeout_minutes'));
+    $count = Order::query()->where('status', OrderStatus::Pending->value)
+        ->where('created_at', '<', $cutoff)
+        ->get()->each(function (Order $order) {
+            DB::transaction(function () use ($order) {
+                foreach ($order->items as $item) {
+                    TicketType::query()->where('id', $item->ticket_type_id)
+                        ->lockForUpdate()->decrement('sold_count', $item->quantity);
+                }
+                $order->forceFill(['status' => OrderStatus::Cancelled])->save();
+                $order->items()->each(fn ($i) => $i->assignments()->delete());
+                OrderCancelled::dispatch($order, 'cart_timeout');
+            });
+        })->count();
+    $this->info("Cancelled {$count} pending order(s).");
+    return self::SUCCESS;
+}
+```
+
+- [ ] **Step 2–9: Remaining commands**
+
+Each mirrors spec §20. Implementation follows the support classes built earlier.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/Console tests
+git commit -m "feat(events): add console commands"
+```
+
+---
+
+## Task 24: Top-level Events facade
+
+**Files:** `src/Support/Events.php`, `src/Facades/Events.php` (thin facade).
+
+- [ ] **Step 1: Facade-class implementation**
+
+Implements every method from spec §15. Bound as singleton in provider.
+
+Each method runs inside `DB::transaction(...)` where state changes. Uses pessimistic lock on `ticket_types` row inside `reserve(...)` per spec §16.3.
+
+```php
+public function reserve(TicketType $type, Model $buyer, int $quantity, array $holderAssignments, ?string $discountCode = null, ?int $unitPriceMinorOverride = null): Order
+{
+    return DB::transaction(function () use ($type, $buyer, $quantity, $holderAssignments, $discountCode, $unitPriceMinorOverride) {
+        $type = TicketType::query()->lockForUpdate()->findOrFail($type->id);
+        if (count($holderAssignments) !== $quantity) throw new InvalidArgumentException('Assignment count mismatch');
+        if ($type->capacity !== null && ($type->capacity - $type->sold_count) < $quantity) {
+            throw new TicketTypeSoldOut();
+        }
+        $unitPrice = $unitPriceMinorOverride ?? $type->currentUnitPriceMinor();
+        if ($type->minimum_price_minor !== null && $unitPrice < $type->minimum_price_minor) {
+            throw new InvalidArgumentException('Below minimum price');
+        }
+        $subtotal = $unitPrice * $quantity;
+
+        // Apply discount via PriceCalculator if code supplied
+        $draft = /* construct DraftOrder */;
+        $breakdown = $this->prices->apply($draft, $discountCode ? DiscountCode::query()->where('code', $discountCode)->first() : null);
+
+        $order = Order::create([
+            'event_id' => $type->event_id, 'user_id' => $buyer->getKey(),
+            'status' => OrderStatus::Pending,
+            'subtotal_minor' => $breakdown->subtotalMinor,
+            'discount_minor' => $breakdown->discountMinor,
+            'tax_minor' => 0, 'total_minor' => $breakdown->totalMinor,
+            'currency' => $breakdown->currency,
+        ]);
+        $orderItem = $order->items()->create([
+            'ticket_type_id' => $type->id,
+            'price_tier_id' => $type->activePriceTier()?->id,
+            'quantity' => $quantity,
+            'unit_price_minor' => $unitPrice,
+            'line_total_minor' => $unitPrice * $quantity,
+        ]);
+        foreach ($holderAssignments as $i => $assignment) {
+            $orderItem->assignments()->create([
+                'seat_index' => $i,
+                'holder_user_id' => $assignment['user_id'] ?? null,
+                'holder_name' => $assignment['name'],
+                'holder_email' => $assignment['email'],
+                'holder_metadata' => $assignment['metadata'] ?? null,
+            ]);
+        }
+        $type->increment('sold_count', $quantity);
+        Event::query()->where('id', $type->event_id)->increment('tickets_sold_count', $quantity);
+
+        OrderCreated::dispatch($order);
+        return $order;
+    });
+}
+```
+
+- [ ] **Step 2: pay()** flips status to Paid, triggers `OrderObserver` which issues tickets + accrues payouts + completes transfers.
+
+- [ ] **Step 3: All remaining methods**
+
+Implement per spec §15. Each emits the matching domain event.
+
+- [ ] **Step 4: Tests + commit**
+
+```bash
+git add src/Support/Events.php src/Facades tests
+git commit -m "feat(events): add top-level Events facade"
+```
+
+---
+
+## Task 25: EventsServiceProvider
+
+**Files:** `src/Providers/EventsServiceProvider.php`.
+
+- [ ] **Step 1: Provider**
+
+```php
+final class EventsServiceProvider extends PackageServiceProvider
+{
+    protected function module(): string { return 'events'; }
+
+    public function configurePackage(Package $package): void
+    {
+        $package
+            ->name('laravel-modules-events')
+            ->hasConfigFile('events')
+            ->hasTranslations()
+            ->hasMigrations([/* list every migration filename */])
+            ->hasCommands([
+                ReleaseQueueCommand::class, PruneQueueCommand::class,
+                ExpireWaitlistClaimsCommand::class, GenerateOccurrencesCommand::class,
+                DispatchRemindersCommand::class, ExpirePendingOrdersCommand::class,
+                DispatchAnnouncementsCommand::class, EnforceRetentionCommand::class,
+                DemoCommand::class,
+            ])
+            ->hasViews('events');
+    }
+
+    public function packageRegistered(): void
+    {
+        $this->app->singleton(Events::class, fn () => new Events(/* inject deps */));
+        $this->app->singleton(QrTokenSigner::class, fn () => new QrTokenSigner(config('app.key')));
+        $this->app->singleton(RequirementEngine::class);
+        $this->app->scoped(QueueReleaser::class);
+        $this->app->scoped(WaitlistPromoter::class);
+        $this->app->scoped(RefundCoordinator::class);
+        $this->app->scoped(PayoutAccruer::class);
+        $this->app->scoped(AuditLogWriter::class);
+        $this->app->scoped(EventCloner::class);
+    }
+
+    public function packageBooted(): void
+    {
+        Event::observe(EventObserver::class);
+        Order::observe(OrderObserver::class);
+        Ticket::observe(TicketObserver::class);
+        Attendee::observe(AttendeeObserver::class);
+        Application::observe(ApplicationObserver::class);
+
+        $gate = $this->app['Illuminate\Contracts\Auth\Access\Gate'];
+        $gate->policy(Event::class, EventPolicy::class);
+        $gate->policy(TicketType::class, TicketTypePolicy::class);
+        $gate->policy(Order::class, OrderPolicy::class);
+        $gate->policy(Application::class, ApplicationPolicy::class);
+        $gate->policy(Refund::class, RefundPolicy::class);
+
+        // Schedule commands per spec §20
+        if ($this->app->runningInConsole()) {
+            $this->app->booted(function () {
+                $schedule = $this->app->make(Schedule::class);
+                $schedule->command(ReleaseQueueCommand::class)->everyTenSeconds();
+                $schedule->command(PruneQueueCommand::class)->everyMinute();
+                $schedule->command(ExpireWaitlistClaimsCommand::class)->everyMinute();
+                $schedule->command(ExpirePendingOrdersCommand::class)->everyMinute();
+                $schedule->command(DispatchAnnouncementsCommand::class)->everyMinute();
+                $schedule->command(DispatchRemindersCommand::class)->everyFiveMinutes();
+                $schedule->command(GenerateOccurrencesCommand::class)->daily();
+                $schedule->command(EnforceRetentionCommand::class)->daily();
+            });
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/Providers
+git commit -m "feat(events): add EventsServiceProvider"
+```
+
+---
+
+## Task 26: Test base + feature tests
+
+**Files:** `tests/{Pest,TestCase}.php`, `tests/Stubs/StubUser.php`, `tests/migrations/2026_05_28_000010_create_media_table.php`, plus per-feature test files.
+
+- [ ] **Step 1: TestCase**
+
+```php
+abstract class TestCase extends PackageTestCase
+{
+    protected function modulePackageProviders($app): array
+    {
+        return [
+            MediaLibraryServiceProvider::class,
+            Cviebrock\EloquentSluggable\ServiceProvider::class,
+            EventsServiceProvider::class,
+        ];
+    }
+    protected function defineDatabaseMigrations(): void
+    {
+        parent::defineDatabaseMigrations();
+        $this->loadMigrationsFrom(__DIR__.'/migrations');
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+    }
+}
+```
+
+- [ ] **Step 2: Feature tests per spec §23**
+
+Each test file is small (one scenario per `it()` block). Test file names:
+- `tests/Feature/Catalog/EventLifecycleTest.php`
+- `tests/Feature/Catalog/EventCloningTest.php`
+- `tests/Feature/Catalog/EventTemplateTest.php`
+- `tests/Feature/Ticketing/PurchaseHappyPathTest.php` — full reserve→pay→ticket-issued with group assignments
+- `tests/Feature/Ticketing/PriceTiersTest.php`
+- `tests/Feature/Ticketing/TransferTest.php` — free + with-fee + deadline rejected
+- `tests/Feature/Ticketing/DiscountCodeTest.php` — all 6 sub-cases
+- `tests/Feature/Ticketing/AddOnTest.php`
+- `tests/Feature/Ticketing/ReferralAttributionTest.php`
+- `tests/Feature/Attendance/ApplicationFlowTest.php`
+- `tests/Feature/Attendance/MultiSessionTest.php`
+- `tests/Feature/Attendance/AnnouncementTest.php`
+- `tests/Feature/Attendance/AttendeeListVisibilityTest.php`
+- `tests/Feature/Eligibility/RequirementMatrixTest.php`
+- `tests/Feature/Eligibility/DocumentVerificationTest.php`
+- `tests/Feature/Flow/QueueReleaseTest.php`
+- `tests/Feature/Flow/WaitlistTest.php`
+- `tests/Feature/Flow/RefundFlowTest.php`
+- `tests/Feature/Flow/EuRefundWindowTest.php`
+- `tests/Feature/Flow/PayoutsTest.php`
+- `tests/Feature/Sponsors/SponsorshipTest.php`
+- `tests/Feature/Audit/AuditLogTest.php`
+- `tests/Feature/Gdpr/PersonalDataExportTest.php`
+- `tests/Feature/Gdpr/AnonymizeTest.php`
+- `tests/Feature/Console/ExpirePendingOrdersTest.php`
+- `tests/Feature/Console/EnforceRetentionTest.php`
+
+Each test file has 3–8 tests. Target ~80 total tests.
+
+- [ ] **Step 3: Commit progressively (one commit per sub-aggregate's tests)**
+
+```bash
+git add tests/Feature/Catalog && git commit -m "test(events): add Catalog feature tests"
+git add tests/Feature/Ticketing && git commit -m "test(events): add Ticketing feature tests"
+# … continue for each
+```
+
+---
+
+## Task 27: CI + docs
+
+**Files:** `.github/workflows/tests.yml`, `.github/dependabot.yml`, `README.md`, `CHANGELOG.md`, `UPGRADE-1.0.md`, `docs/gdpr/{data-flow.md,processing-record.md,dsr-checklist.md}`.
+
+- [ ] **Step 1: Copy CI from Chat**
+
+```bash
+cp ../KurtModules-Chat/.github/workflows/tests.yml .github/workflows/tests.yml
+cp ../KurtModules-Chat/.github/dependabot.yml .github/dependabot.yml
+```
+
+- [ ] **Step 2: README + CHANGELOG + UPGRADE**
+
+Standard format, describing what's included + Filament v1.1 promise.
+
+- [ ] **Step 3: GDPR docs**
+
+Three markdown files per spec §25.5.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github README.md CHANGELOG.md UPGRADE-1.0.md docs
+git commit -m "ci+docs: add github actions, README, CHANGELOG, UPGRADE-1.0, GDPR docs"
+```
+
+---
+
+## Task 28: Push + PR + tag
+
+- [ ] **Step 1: Push**
+
+```bash
+git push -u origin v1.0
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "v1.0: initial release of ozankurt/laravel-modules-events" --body "$(cat <<'EOF'
+## Summary
+
+- Greenfield payment-agnostic event management module.
+- 32 tables across 5 sub-aggregates (Catalog, Ticketing, Attendance, Eligibility, Flow).
+- Open/Application/RSVP registration; group ticket assignment; multi-session events.
+- Sale queue + waitlist; full Refund model with EU consumer-protection window.
+- Discount codes (percent + flat amount), price tiers (early-bird), add-ons (parking/dinner/merch).
+- Sponsors with tiers + comp tickets; referral attribution + lightweight co-organizer payouts.
+- Bulk announcements; audit log; event templates + cloning.
+- GDPR helpers: export, anonymize, retention command, DPIA docs.
+- Optional Laravel Notifications (Mail + Database) + default Blade templates.
+- Filament admin lands in v1.1.
+
+## Test plan
+- [x] vendor/bin/pint --test
+- [x] vendor/bin/phpstan analyse
+- [x] vendor/bin/pest (~80 tests)
+- [ ] CI matrix green on this PR
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI green, merge, tag**
+
+```bash
+gh pr checks <number> --watch
+gh pr merge <number> --merge
+git switch master && git pull
+git tag -a v1.0.0 -m "v1.0.0"
+git push origin v1.0.0
+gh release create v1.0.0 --title "v1.0.0" --notes-file CHANGELOG.md
+```
+
+---
+
+## Definition of done
+
+- [ ] All 40 migrations applied; smoke test confirms every table present.
+- [ ] PriceCalculator covers all 6 discount-code edge cases.
+- [ ] RequirementEngine + every default evaluator tested.
+- [ ] QueueReleaser, WaitlistPromoter, RefundCoordinator, PayoutAccruer, AuditLogWriter all tested.
+- [ ] TransferEngine free + with-fee paths work.
+- [ ] GDPR exporter + anonymizer behave per spec.
+- [ ] EU consumer-protection refund auto-approves inside window + non-exempt + uncheckedin.
+- [ ] Pint + PHPStan level 8 + Pest all green (~80 tests).
+- [ ] CI matrix green on Laravel 12.
+- [ ] README + CHANGELOG + UPGRADE-1.0 + GDPR docs in place.
+- [ ] Tag `v1.0.0` cut + GitHub release published.
+- [ ] PR notes that Filament admin resources are deferred to v1.1.

--- a/docs/superpowers/plans/2026-05-30-kurtmodules-media-library-v1.md
+++ b/docs/superpowers/plans/2026-05-30-kurtmodules-media-library-v1.md
@@ -1,0 +1,1884 @@
+# `ozankurt/laravel-modules-media-library` v1.0 — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build `ozankurt/laravel-modules-media-library` v1.0.0 — WordPress-style media bucket for Laravel SaaS. Headless backend wrapping spatie/laravel-medialibrary as the storage engine, with nested folders, polymorphic owner + many-to-many attachments, focal-point conversions, replace-with-stable-id versioning, share links, folder ACL, tag taxonomy, pluggable extractors.
+
+**Architecture:** Five-area layout (Catalog / Storage / Sharing / Access / Search) plus cross-cutting Contracts/Events/Notifications/Policies. Top-level `MediaLibrary` facade orchestrates the workflows. Each MediaLibraryItem owns one thin `MediaLibraryStorage` host (a `HasMedia` model with a single `mli` collection) which in turn owns the actual spatie Media row. Polymorphic attachments link consumer models to MediaLibraryItem ids (stable across replaces).
+
+**Tech Stack:** PHP 8.4, Laravel 12, Pest 3 + Testbench, PHPStan 8, Pint, Rector. Runtime deps: ozankurt/laravel-modules-core ^2.0, spatie/laravel-medialibrary ^11, spatie/laravel-translatable ^6.11, cviebrock/eloquent-sluggable ^11|^12, intervention/image ^3, spatie/laravel-package-tools ^1.92.
+
+**Spec:** [2026-05-30-kurtmodules-media-library-v1-spec.md](../specs/2026-05-30-kurtmodules-media-library-v1-spec.md)
+
+**Working directory:** `D:\Code\Projects\KurtModules-MediaLibrary`. Repo does NOT yet exist on GitHub; Task 0 creates it.
+
+**Defer to v1.1:** Filament v3/v4/v5 resources, Scout default adapter, cross-module audit log promotion.
+
+---
+
+## File structure
+
+```
+src/
+  Catalog/
+    Enums/{Visibility, ItemKind, AttachmentRole}.php
+    Models/{MediaLibraryItem, MediaLibraryFolder, MediaLibraryTag, MediaLibraryAttachment, MediaLibrarySavedSearch, MediaLibraryStorage}.php
+    Observers/{MediaLibraryItemObserver, MediaLibraryFolderObserver}.php
+    Support/{FolderPathBuilder, ItemSlugger}.php
+  Storage/
+    Enums/PendingUploadStatus.php
+    Models/{MediaLibraryVersion, MediaLibraryVariant, MediaLibraryPendingUpload}.php
+    Support/{UploadCoordinator, ConversionEngine, VariantGenerator, FocalPointCropper, ReplaceCoordinator, MetadataExtractor}.php
+    Contracts/{ExifExtractor, OcrExtractor, AiTagger, BlurhashGenerator, PaletteExtractor}.php
+    Extractors/{DefaultExifExtractor, InterventionBlurhashGenerator, InterventionPaletteExtractor}.php
+  Sharing/
+    Enums/{ShareAbility, AccessAction}.php
+    Models/{ShareLink, AccessLogEntry}.php
+    Support/{ShareLinkSigner, ShareLinkResolver, AccessLogger}.php
+    Http/Controllers/ShareLinkController.php
+  Access/
+    Enums/{Capability, SubjectType}.php
+    Models/FolderPermission.php
+    Contracts/MediaSubjectResolver.php
+    Support/{DefaultSubjectResolver, FolderPermissionResolver, MediaLibraryAccess}.php
+    Values/Subject.php
+  Search/
+    Contracts/ScoutAdapter.php
+    Support/DefaultSearchEngine.php
+  Concerns/
+    HasMediaLibraryItems.php
+    IsMediaLibraryOwner.php
+  Contracts/MediaLibraryOwner.php
+  Console/Commands/{PruneVersions, PruneVariants, RebuildPaths, Recount, ExpireShares, PruneShares, ExpirePendingUploads, Reextract, Reindex, Demo}Command.php
+  Events/...
+  Exceptions/{OwnerNotResolved, InvalidUpload, ReplaceFailed, ShareLinkInvalid, SelfReferentialFolder}.php
+  Notifications/{ShareLinkCreated, ShareLinkAccessed, ItemReplaced, LargeUploadCompleted}.php
+  Policies/{MediaLibraryItemPolicy, MediaLibraryFolderPolicy, ShareLinkPolicy, SavedSearchPolicy}.php
+  Providers/MediaLibraryServiceProvider.php
+  Support/MediaLibrary.php
+  Facades/MediaLibrary.php
+routes/share.php
+config/media-library.php
+resources/views/notifications/*.blade.php
+database/factories/...
+database/migrations/...
+tests/Pest.php
+tests/TestCase.php
+tests/Stubs/StubUser.php
+tests/migrations/2026_05_28_000010_create_media_table.php
+.github/workflows/tests.yml
+.github/dependabot.yml
+phpstan.neon
+pint.json
+rector.php
+phpunit.xml.dist
+.gitattributes
+.gitignore
+README.md
+CHANGELOG.md
+UPGRADE-1.0.md
+LICENSE.md
+SECURITY.md
+composer.json
+```
+
+---
+
+## Task 0: GitHub repo + local scaffold
+
+- [ ] **Step 1: Create GitHub repo + clone**
+
+```bash
+gh repo create OzanKurt/KurtModules-MediaLibrary --public --description "WordPress-style media bucket for Laravel SaaS: tenant-aware folders, polymorphic attachments, focal-point conversions, replace-with-stable-id, share links, folder ACL." --license=mit
+cd D:/Code/Projects
+git clone https://github.com/OzanKurt/KurtModules-MediaLibrary.git
+cd KurtModules-MediaLibrary
+git branch -m main master  # match family convention
+git push -u origin master
+gh api -X PATCH 'repos/OzanKurt/KurtModules-MediaLibrary' -f default_branch=master
+gh api -X DELETE 'repos/OzanKurt/KurtModules-MediaLibrary/git/refs/heads/main' || true
+```
+
+- [ ] **Step 2: Copy SECURITY.md from Core, branch v1.0**
+
+```bash
+cp ../KurtModules-Core/SECURITY.md .
+git add SECURITY.md
+git commit -m "chore: bootstrap repo with SECURITY.md"
+git push origin master
+git switch -c v1.0
+```
+
+---
+
+## Task 1: composer.json
+
+**Files:**
+- Create: `composer.json`
+
+- [ ] **Step 1: Write composer.json**
+
+```json
+{
+  "name": "ozankurt/laravel-modules-media-library",
+  "description": "WordPress-style media bucket for Laravel SaaS: tenant-aware folders, polymorphic attachments, focal-point conversions, replace-with-stable-id, share links, folder ACL.",
+  "keywords": ["laravel", "filament", "kurtmodules", "media-library", "wordpress"],
+  "license": "MIT",
+  "authors": [{ "name": "Ozan Kurt", "email": "ozankurt2@gmail.com" }],
+  "require": {
+    "php": "^8.4",
+    "illuminate/contracts": "^12.0 || ^13.0",
+    "illuminate/database": "^12.0 || ^13.0",
+    "illuminate/support": "^12.0 || ^13.0",
+    "cviebrock/eloquent-sluggable": "^11.0 || ^12.0",
+    "intervention/image": "^3.0",
+    "ozankurt/laravel-modules-core": "^2.0",
+    "spatie/laravel-medialibrary": "^11.0",
+    "spatie/laravel-package-tools": "^1.92",
+    "spatie/laravel-translatable": "^6.11"
+  },
+  "require-dev": {
+    "filament/filament": "^3.0 || ^4.0 || ^5.0",
+    "larastan/larastan": "^3.0",
+    "laravel/pint": "^1.18",
+    "mockery/mockery": "^1.6",
+    "orchestra/testbench": "^10.0",
+    "pestphp/pest": "^3.0",
+    "pestphp/pest-plugin-laravel": "^3.0",
+    "rector/rector": "^2.0"
+  },
+  "autoload": { "psr-4": { "Kurt\\Modules\\MediaLibrary\\": "src/" } },
+  "autoload-dev": {
+    "psr-4": {
+      "Kurt\\Modules\\MediaLibrary\\Tests\\": "tests/",
+      "Database\\Factories\\Kurt\\Modules\\MediaLibrary\\": "database/factories/"
+    }
+  },
+  "extra": { "laravel": { "providers": ["Kurt\\Modules\\MediaLibrary\\Providers\\MediaLibraryServiceProvider"] } },
+  "repositories": [
+    { "type": "vcs", "url": "https://github.com/OzanKurt/KurtModules-Core" }
+  ],
+  "config": { "sort-packages": true, "allow-plugins": { "pestphp/pest-plugin": true } },
+  "scripts": {
+    "test": "vendor/bin/pest",
+    "lint": "vendor/bin/pint --test",
+    "format": "vendor/bin/pint",
+    "stan": "vendor/bin/phpstan analyse --memory-limit=2G"
+  },
+  "minimum-stability": "stable",
+  "prefer-stable": true
+}
+```
+
+- [ ] **Step 2: composer install + commit**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe composer.phar install --no-interaction
+git add composer.json composer.lock
+git commit -m "feat: composer scaffold for laravel-modules-media-library v1"
+```
+
+---
+
+## Task 2: Dev configs
+
+**Files:**
+- Copy: `pint.json`, `phpstan.neon`, `rector.php`, `.gitattributes`, `.gitignore`, `phpunit.xml.dist` from `../KurtModules-Events/`
+
+- [ ] **Step 1: Copy + commit**
+
+```bash
+cp ../KurtModules-Events/pint.json .
+cp ../KurtModules-Events/phpstan.neon .
+cp ../KurtModules-Events/rector.php .
+cp ../KurtModules-Events/.gitattributes .
+cp ../KurtModules-Events/.gitignore .
+cp ../KurtModules-Events/phpunit.xml.dist .
+git add pint.json phpstan.neon rector.php .gitattributes .gitignore phpunit.xml.dist
+git commit -m "chore: add pint, phpstan, rector, phpunit configs"
+```
+
+---
+
+## Task 3: config/media-library.php
+
+**Files:**
+- Create: `config/media-library.php`
+
+- [ ] **Step 1: Write full config**
+
+Use the exact block from spec §19.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add config/media-library.php
+git commit -m "feat(media-library): add config file"
+```
+
+---
+
+## Task 4: Enums
+
+**Files:**
+- Create: `src/Catalog/Enums/{Visibility,ItemKind,AttachmentRole}.php`
+- Create: `src/Storage/Enums/PendingUploadStatus.php`
+- Create: `src/Sharing/Enums/{ShareAbility,AccessAction}.php`
+- Create: `src/Access/Enums/{Capability,SubjectType}.php`
+- Create: `tests/Unit/Enums/*Test.php`
+
+TDD per enum. Use exact case names + values from spec §6.
+
+- [ ] **Step 1: Catalog enums**
+
+`src/Catalog/Enums/Visibility.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\MediaLibrary\Catalog\Enums;
+
+enum Visibility: string
+{
+    case Private = 'private';
+    case Restricted = 'restricted';
+    case Public = 'public';
+}
+```
+
+Test (`tests/Unit/Enums/Catalog/VisibilityTest.php`):
+```php
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\MediaLibrary\Catalog\Enums\Visibility;
+
+it('exposes private, restricted, public', function () {
+    expect(Visibility::Private->value)->toBe('private');
+    expect(Visibility::Restricted->value)->toBe('restricted');
+    expect(Visibility::Public->value)->toBe('public');
+});
+```
+
+Repeat for `ItemKind` (Image/Video/Audio/Document/Archive/Other), `AttachmentRole` (Cover/Social/Gallery/Thumbnail/Attachment/Hero/Logo/Favicon).
+
+- [ ] **Step 2: Storage enums**
+
+`PendingUploadStatus` (Pending/Completed/Cancelled/Expired).
+
+- [ ] **Step 3: Sharing enums**
+
+`ShareAbility` (View/Download), `AccessAction` (View/Download/Upload/Replace/Delete).
+
+- [ ] **Step 4: Access enums**
+
+`Capability` with `rank()` method (View=1, Download=2, Manage=3). `SubjectType` (User/Role/Everyone).
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\MediaLibrary\Access\Enums;
+
+enum Capability: string
+{
+    case View = 'view';
+    case Download = 'download';
+    case Manage = 'manage';
+
+    public function rank(): int
+    {
+        return match ($this) {
+            self::View => 1,
+            self::Download => 2,
+            self::Manage => 3,
+        };
+    }
+}
+```
+
+Test the rank ordering as part of the CapabilityTest.
+
+- [ ] **Step 5: Run + commit**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pest tests/Unit/Enums
+git add src/Catalog/Enums src/Storage/Enums src/Sharing/Enums src/Access/Enums tests/Unit/Enums
+git commit -m "feat(media-library): add enums across sub-areas"
+```
+
+Expected: ~10 enum tests pass.
+
+---
+
+## Task 5: Migrations
+
+**Files:**
+- Create: 13 migrations under `database/migrations/` per spec §5.
+
+Order:
+1. `2026_05_30_000010_create_media_library_folders_table.php`
+2. `2026_05_30_000020_create_media_library_storage_table.php`
+3. `2026_05_30_000030_create_media_library_items_table.php`
+4. `2026_05_30_000040_create_media_library_tags_table.php`
+5. `2026_05_30_000050_create_media_library_item_tag_table.php`
+6. `2026_05_30_000060_create_media_library_attachments_table.php`
+7. `2026_05_30_000070_create_media_library_saved_searches_table.php`
+8. `2026_05_30_000080_create_media_library_versions_table.php`
+9. `2026_05_30_000090_create_media_library_variants_table.php`
+10. `2026_05_30_000100_create_media_library_pending_uploads_table.php`
+11. `2026_05_30_000110_create_media_library_share_links_table.php`
+12. `2026_05_30_000120_create_media_library_access_log_table.php`
+13. `2026_05_30_000130_create_media_library_folder_permissions_table.php`
+
+Each is `return new class extends Migration { … };` with exact columns from spec §5.
+
+Critical points:
+- `media_library_items.storage_id` FK to `media_library_storage` (NOT NULL, cascadeOnDelete).
+- `media_library_storage` has `item_uid` (uuid, unique).
+- Owner columns: `owner_type` string + `owner_id` unsignedBigInteger; combined into a polymorphic index per the spec.
+- All FKs to `users` use `config('auth.providers.users.table', 'users')` with the appropriate delete behavior.
+- All domain rows: `softDeletes()` + `timestamps()`.
+
+- [ ] **Step 1: Write all 13 migrations**
+
+Iterate one at a time. Verify each table-schema after creation by writing a single Pest test file `tests/Feature/MigrationsTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+
+it('creates every media_library_* table', function () {
+    foreach ([
+        'media_library_folders', 'media_library_storage', 'media_library_items',
+        'media_library_tags', 'media_library_item_tag', 'media_library_attachments',
+        'media_library_saved_searches', 'media_library_versions', 'media_library_variants',
+        'media_library_pending_uploads', 'media_library_share_links', 'media_library_access_log',
+        'media_library_folder_permissions',
+    ] as $table) {
+        expect(Schema::hasTable($table))->toBeTrue("missing {$table}");
+    }
+});
+```
+
+Add minimal `tests/TestCase.php` so the migration test can run:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\MediaLibrary\Tests;
+
+use Kurt\Modules\Core\Providers\CoreServiceProvider;
+use Kurt\Modules\Core\Testing\PackageTestCase;
+
+abstract class TestCase extends PackageTestCase
+{
+    protected function getPackageProviders($app): array
+    {
+        return [CoreServiceProvider::class];
+    }
+
+    protected function defineDatabaseMigrations(): void
+    {
+        parent::defineDatabaseMigrations();
+        $this->loadMigrationsFrom(__DIR__.'/../database/migrations');
+    }
+}
+```
+
+`tests/Pest.php`:
+```php
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\MediaLibrary\Tests\TestCase;
+
+pest()->extend(TestCase::class)->in('Feature');
+```
+
+- [ ] **Step 2: Run + commit**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pest tests/Feature/MigrationsTest.php
+git add database/migrations tests/TestCase.php tests/Pest.php tests/Feature/MigrationsTest.php
+git commit -m "feat(media-library): add all v1 migrations"
+```
+
+Expected: migrations test asserts 13 tables exist.
+
+---
+
+## Task 6: Catalog models + factories
+
+**Files:**
+- Create: `src/Catalog/Models/{MediaLibraryStorage, MediaLibraryFolder, MediaLibraryItem, MediaLibraryTag, MediaLibraryAttachment, MediaLibrarySavedSearch}.php`
+- Create: `database/factories/Catalog/<Model>Factory.php` for each
+- Create: `tests/Feature/Catalog/<Model>Test.php` for each (CRUD + relations + scopes)
+
+Patterns:
+- Translatable models (Folder, Item, Tag) use `HasTranslations` + `public array $translatable = [...]`.
+- Sluggable models (Folder, Item, Tag) use `Sluggable` trait + `sluggable()` method.
+- All models override `newFactory()` for PSR-4 factory namespace.
+
+### Step 1: MediaLibraryStorage
+
+`src/Catalog/Models/MediaLibraryStorage.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\MediaLibrary\Catalog\Models;
+
+use Illuminate\Database\Eloquent\Model;
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+use Spatie\MediaLibrary\MediaCollections\Models\Media;
+
+class MediaLibraryStorage extends Model implements HasMedia
+{
+    use InteractsWithMedia;
+
+    protected $table = 'media_library_storage';
+
+    protected $fillable = ['item_uid'];
+
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('mli')->singleFile();
+    }
+
+    public function registerMediaConversions(?Media $media = null): void
+    {
+        foreach ((array) config('media-library.conversions', []) as $name => $spec) {
+            $width = (int) ($spec['width'] ?? 0);
+            $height = (int) ($spec['height'] ?? 0);
+            $conv = $this->addMediaConversion((string) $name);
+            if ($width > 0) $conv->width($width);
+            if ($height > 0) $conv->height($height);
+            if (($spec['fit'] ?? 'fit') === 'crop') {
+                $conv->fit(\Spatie\Image\Enums\Fit::Crop, $width ?: null, $height ?: null);
+            }
+        }
+    }
+}
+```
+
+Test the host model + media collection registration.
+
+### Step 2: MediaLibraryFolder
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\MediaLibrary\Catalog\Models;
+
+use Cviebrock\EloquentSluggable\Sluggable;
+use Database\Factories\Kurt\Modules\MediaLibrary\Catalog\MediaLibraryFolderFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Eloquent\SoftDeletes;
+use Kurt\Modules\MediaLibrary\Catalog\Enums\Visibility;
+use Spatie\Translatable\HasTranslations;
+
+class MediaLibraryFolder extends Model
+{
+    use HasFactory;
+    use HasTranslations;
+    use Sluggable;
+    use SoftDeletes;
+
+    protected $table = 'media_library_folders';
+
+    /** @var list<string> */
+    public array $translatable = ['name', 'description'];
+
+    protected $fillable = [
+        'owner_type', 'owner_id', 'parent_id', 'slug', 'name', 'description',
+        'path', 'depth', 'position', 'visibility', 'item_count', 'descendant_count', 'created_by',
+    ];
+
+    protected $casts = [
+        'visibility' => Visibility::class,
+        'depth' => 'integer',
+        'position' => 'integer',
+        'item_count' => 'integer',
+        'descendant_count' => 'integer',
+    ];
+
+    public function sluggable(): array
+    {
+        return ['slug' => ['source' => 'name', 'onUpdate' => true]];
+    }
+
+    public function owner(): MorphTo
+    {
+        return $this->morphTo();
+    }
+
+    public function parent(): BelongsTo
+    {
+        return $this->belongsTo(self::class, 'parent_id');
+    }
+
+    public function children(): HasMany
+    {
+        return $this->hasMany(self::class, 'parent_id');
+    }
+
+    public function items(): HasMany
+    {
+        return $this->hasMany(MediaLibraryItem::class, 'folder_id');
+    }
+
+    protected static function newFactory(): MediaLibraryFolderFactory
+    {
+        return MediaLibraryFolderFactory::new();
+    }
+}
+```
+
+Factory + a feature test asserting CRUD + parent/children + items relation.
+
+### Step 3: MediaLibraryItem
+
+Translatable on `title, alt_text, caption, description`. Sluggable on `slug`. Cast `focal_x/focal_y` as float, `palette/exif/ai_tags/metadata` as array, `byte_size/download_count/view_count` as integer.
+
+Key relations:
+```php
+public function owner(): MorphTo { return $this->morphTo(); }
+public function folder(): BelongsTo { return $this->belongsTo(MediaLibraryFolder::class); }
+public function storage(): BelongsTo { return $this->belongsTo(MediaLibraryStorage::class, 'storage_id'); }
+public function tags(): BelongsToMany { return $this->belongsToMany(MediaLibraryTag::class, 'media_library_item_tag', 'item_id', 'tag_id')->withTimestamps(); }
+public function attachments(): HasMany { return $this->hasMany(MediaLibraryAttachment::class, 'item_id'); }
+public function versions(): HasMany { return $this->hasMany(\Kurt\Modules\MediaLibrary\Storage\Models\MediaLibraryVersion::class, 'item_id'); }
+public function variants(): HasMany { return $this->hasMany(\Kurt\Modules\MediaLibrary\Storage\Models\MediaLibraryVariant::class, 'item_id'); }
+```
+
+Methods:
+
+```php
+public function spatieMedia(): ?\Spatie\MediaLibrary\MediaCollections\Models\Media
+{
+    return $this->storage?->getFirstMedia('mli');
+}
+
+public function url(?string $conversion = null): string
+{
+    $media = $this->spatieMedia();
+    if ($media === null) return '';
+    return $conversion === null ? $media->getUrl() : $media->getUrl($conversion);
+}
+
+public function variant(array $spec): \Kurt\Modules\MediaLibrary\Storage\Models\MediaLibraryVariant
+{
+    return app(\Kurt\Modules\MediaLibrary\Storage\Support\VariantGenerator::class)->generateOrFetch($this, $spec);
+}
+
+public function activeShares(): \Illuminate\Database\Eloquent\Collection
+{
+    return $this->shareLinks()->whereNull('revoked_at')->where(function ($q) {
+        $q->whereNull('expires_at')->orWhere('expires_at', '>', now());
+    })->get();
+}
+
+public function shareLinks(): HasMany
+{
+    return $this->hasMany(\Kurt\Modules\MediaLibrary\Sharing\Models\ShareLink::class, 'item_id');
+}
+```
+
+Scopes per spec §14.1 (`byOwner`, `byFolder`, `byTag`, `byMimeType`, `byDateRange`, `search`).
+
+### Step 4: MediaLibraryTag
+
+```php
+public array $translatable = ['name'];
+protected $fillable = ['owner_type', 'owner_id', 'slug', 'name', 'color', 'position'];
+
+public function items(): BelongsToMany
+{
+    return $this->belongsToMany(MediaLibraryItem::class, 'media_library_item_tag', 'tag_id', 'item_id');
+}
+```
+
+### Step 5: MediaLibraryAttachment
+
+```php
+protected $fillable = ['item_id', 'attachable_type', 'attachable_id', 'role', 'position'];
+protected $casts = ['position' => 'integer'];
+
+public function item(): BelongsTo
+{
+    return $this->belongsTo(MediaLibraryItem::class, 'item_id');
+}
+
+public function attachable(): MorphTo
+{
+    return $this->morphTo();
+}
+```
+
+### Step 6: MediaLibrarySavedSearch
+
+```php
+protected $fillable = ['user_id', 'name', 'filters'];
+protected $casts = ['filters' => 'array'];
+
+public function user(): BelongsTo
+{
+    return $this->belongsTo(config('auth.providers.users.model'), 'user_id');
+}
+```
+
+### Step 7: Run + commit
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pint --test
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/phpstan analyse --memory-limit=2G
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pest tests/Feature/Catalog
+git add src/Catalog database/factories tests
+git commit -m "feat(media-library): add Catalog models, factories, relations, scopes"
+```
+
+Expected: ~12 catalog tests pass.
+
+---
+
+## Task 7: Storage models + factories
+
+**Files:**
+- Create: `src/Storage/Models/{MediaLibraryVersion, MediaLibraryVariant, MediaLibraryPendingUpload}.php`
+- Factories under `database/factories/Storage/`
+
+- [ ] **Step 1: MediaLibraryVersion**
+
+```php
+protected $fillable = ['item_id', 'spatie_media_id', 'filename', 'mime_type', 'byte_size', 'changelog', 'created_by'];
+protected $casts = ['byte_size' => 'integer'];
+
+public function item(): BelongsTo { return $this->belongsTo(MediaLibraryItem::class, 'item_id'); }
+public function creator(): BelongsTo { return $this->belongsTo(config('auth.providers.users.model'), 'created_by'); }
+```
+
+- [ ] **Step 2: MediaLibraryVariant**
+
+```php
+protected $fillable = ['item_id', 'key', 'spec', 'path', 'mime_type', 'byte_size', 'last_used_at', 'generated_at'];
+protected $casts = ['spec' => 'array', 'last_used_at' => 'datetime', 'generated_at' => 'datetime', 'byte_size' => 'integer'];
+
+public function item(): BelongsTo { return $this->belongsTo(MediaLibraryItem::class, 'item_id'); }
+```
+
+- [ ] **Step 3: MediaLibraryPendingUpload**
+
+```php
+protected $fillable = ['owner_type', 'owner_id', 'upload_id', 'filename', 'mime_type', 'byte_size', 'driver', 'driver_payload', 'status', 'completed_at', 'expires_at', 'created_by'];
+protected $casts = ['driver_payload' => 'array', 'status' => PendingUploadStatus::class, 'completed_at' => 'datetime', 'expires_at' => 'datetime', 'byte_size' => 'integer'];
+
+public function owner(): MorphTo { return $this->morphTo(); }
+```
+
+- [ ] **Step 4: Tests + commit**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pest tests/Feature/Storage
+git add src/Storage database/factories tests
+git commit -m "feat(media-library): add Storage models (version, variant, pending upload)"
+```
+
+---
+
+## Task 8: Sharing + Access models
+
+**Files:**
+- Create: `src/Sharing/Models/{ShareLink, AccessLogEntry}.php`
+- Create: `src/Access/Models/FolderPermission.php`
+- Create: `src/Access/Values/Subject.php`
+- Factories + tests
+
+- [ ] **Step 1: ShareLink**
+
+```php
+protected $fillable = ['item_id', 'folder_id', 'token', 'abilities', 'invitee_email', 'expires_at', 'revoked_at', 'access_count', 'last_accessed_at', 'last_accessed_ip', 'created_by'];
+protected $casts = ['abilities' => 'array', 'expires_at' => 'datetime', 'revoked_at' => 'datetime', 'last_accessed_at' => 'datetime', 'access_count' => 'integer'];
+
+public function item(): BelongsTo { return $this->belongsTo(MediaLibraryItem::class); }
+public function folder(): BelongsTo { return $this->belongsTo(MediaLibraryFolder::class); }
+public function creator(): BelongsTo { return $this->belongsTo(config('auth.providers.users.model'), 'created_by'); }
+
+public function isExpired(): bool { return $this->expires_at !== null && $this->expires_at->isPast(); }
+public function isActive(): bool { return $this->revoked_at === null && ! $this->isExpired(); }
+```
+
+- [ ] **Step 2: AccessLogEntry**
+
+```php
+protected $fillable = ['item_id', 'share_link_id', 'user_id', 'action', 'ip', 'user_agent', 'occurred_at'];
+protected $casts = ['action' => AccessAction::class, 'occurred_at' => 'datetime'];
+
+public function item(): BelongsTo { return $this->belongsTo(MediaLibraryItem::class); }
+public function shareLink(): BelongsTo { return $this->belongsTo(ShareLink::class); }
+public function user(): BelongsTo { return $this->belongsTo(config('auth.providers.users.model'), 'user_id'); }
+```
+
+- [ ] **Step 3: FolderPermission**
+
+```php
+protected $fillable = ['folder_id', 'subject_type', 'subject_value', 'capability', 'cascade'];
+protected $casts = ['subject_type' => SubjectType::class, 'capability' => Capability::class, 'cascade' => 'boolean'];
+
+public function folder(): BelongsTo { return $this->belongsTo(MediaLibraryFolder::class); }
+```
+
+- [ ] **Step 4: Subject value object**
+
+```php
+namespace Kurt\Modules\MediaLibrary\Access\Values;
+
+use Kurt\Modules\MediaLibrary\Access\Enums\SubjectType;
+
+final readonly class Subject
+{
+    public function __construct(public SubjectType $type, public ?string $value) {}
+
+    public function matches(string $rowType, ?string $rowValue): bool
+    {
+        if ($this->type->value !== $rowType) return false;
+        if ($this->type === SubjectType::Everyone) return true;
+        return $this->value === $rowValue;
+    }
+}
+```
+
+- [ ] **Step 5: Tests + commit**
+
+```bash
+git add src/Sharing src/Access database/factories tests
+git commit -m "feat(media-library): add Sharing + Access models with Subject value"
+```
+
+---
+
+## Task 9: Contracts + traits
+
+**Files:**
+- Create: `src/Contracts/MediaLibraryOwner.php`
+- Create: `src/Storage/Contracts/{ExifExtractor, OcrExtractor, AiTagger, BlurhashGenerator, PaletteExtractor}.php`
+- Create: `src/Access/Contracts/MediaSubjectResolver.php`
+- Create: `src/Search/Contracts/ScoutAdapter.php`
+- Create: `src/Concerns/{HasMediaLibraryItems, IsMediaLibraryOwner}.php`
+- Create: `src/Exceptions/{OwnerNotResolved, InvalidUpload, ReplaceFailed, ShareLinkInvalid, SelfReferentialFolder}.php`
+
+- [ ] **Step 1: MediaLibraryOwner contract**
+
+```php
+namespace Kurt\Modules\MediaLibrary\Contracts;
+
+interface MediaLibraryOwner
+{
+    public function getKey(): int|string;
+    public function getMorphClass(): string;
+    public function getMediaLibraryDisplayName(): string;
+}
+```
+
+- [ ] **Step 2: Storage contracts**
+
+```php
+namespace Kurt\Modules\MediaLibrary\Storage\Contracts;
+
+interface ExifExtractor { public function extract(string $path): array; }
+
+interface OcrExtractor { public function extract(string $path): string; }
+
+/** @return array<int, string> */
+interface AiTagger { public function tag(string $path): array; }
+
+interface BlurhashGenerator { public function generate(string $path): string; }
+
+/** @return array{dominant: string, palette: array<int, string>} */
+interface PaletteExtractor { public function extract(string $path): array; }
+```
+
+- [ ] **Step 3: MediaSubjectResolver**
+
+```php
+namespace Kurt\Modules\MediaLibrary\Access\Contracts;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Kurt\Modules\MediaLibrary\Access\Values\Subject;
+use Kurt\Modules\MediaLibrary\Contracts\MediaLibraryOwner;
+
+interface MediaSubjectResolver
+{
+    /** @return array<int, Subject> */
+    public function subjects(?Authenticatable $user): array;
+
+    public function defaultOwner(?Authenticatable $user): MediaLibraryOwner;
+}
+```
+
+- [ ] **Step 4: ScoutAdapter**
+
+```php
+namespace Kurt\Modules\MediaLibrary\Search\Contracts;
+
+use Illuminate\Database\Eloquent\Collection;
+use Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibraryItem;
+
+interface ScoutAdapter
+{
+    public function index(MediaLibraryItem $item): void;
+    public function unindex(MediaLibraryItem $item): void;
+
+    /** @return Collection<int, MediaLibraryItem> */
+    public function search(string $query, array $filters = [], int $limit = 50): Collection;
+}
+```
+
+- [ ] **Step 5: HasMediaLibraryItems trait**
+
+Use the full body from spec §11.1.
+
+- [ ] **Step 6: IsMediaLibraryOwner trait**
+
+```php
+namespace Kurt\Modules\MediaLibrary\Concerns;
+
+use Illuminate\Database\Eloquent\Relations\MorphMany;
+use Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibraryFolder;
+use Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibraryItem;
+
+/** @mixin \Illuminate\Database\Eloquent\Model */
+trait IsMediaLibraryOwner
+{
+    public function mediaLibraryItems(): MorphMany
+    {
+        return $this->morphMany(MediaLibraryItem::class, 'owner');
+    }
+
+    public function mediaLibraryFolders(): MorphMany
+    {
+        return $this->morphMany(MediaLibraryFolder::class, 'owner');
+    }
+
+    public function getMediaLibraryDisplayName(): string
+    {
+        return (string) ($this->getAttribute('name') ?? $this->getAttribute('email') ?? $this->getKey());
+    }
+}
+```
+
+- [ ] **Step 7: Exceptions**
+
+Each is `final class XYZ extends \RuntimeException {}`.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/Contracts src/Storage/Contracts src/Access/Contracts src/Search/Contracts src/Concerns src/Exceptions
+git commit -m "feat(media-library): add contracts + traits + exceptions"
+```
+
+---
+
+## Task 10: Default extractors
+
+**Files:**
+- Create: `src/Storage/Extractors/{DefaultExifExtractor, InterventionBlurhashGenerator, InterventionPaletteExtractor}.php`
+- Create: `tests/Feature/Storage/Extractors/*Test.php`
+
+- [ ] **Step 1: DefaultExifExtractor**
+
+```php
+final class DefaultExifExtractor implements ExifExtractor
+{
+    /** @return array<string, mixed> */
+    public function extract(string $path): array
+    {
+        if (! function_exists('exif_read_data') || ! is_readable($path)) return [];
+        $data = @exif_read_data($path);
+        return is_array($data) ? array_filter($data, fn ($v) => is_scalar($v) || is_array($v)) : [];
+    }
+}
+```
+
+- [ ] **Step 2: InterventionBlurhashGenerator + PaletteExtractor**
+
+Use Intervention Image 3.x. Blurhash via the algorithm port from `kornrunner/blurhash`. Palette via a 4×4 downsample + most-common-color extraction.
+
+```php
+final class InterventionBlurhashGenerator implements BlurhashGenerator
+{
+    public function generate(string $path): string
+    {
+        if (! class_exists(\kornrunner\Blurhash\Blurhash::class)) {
+            return '';
+        }
+        $manager = new \Intervention\Image\ImageManager(new \Intervention\Image\Drivers\Gd\Driver());
+        $img = $manager->read($path)->scaleDown(32);
+        $pixels = [];
+        for ($y = 0; $y < $img->height(); $y++) {
+            $row = [];
+            for ($x = 0; $x < $img->width(); $x++) {
+                $c = $img->pickColor($x, $y);
+                $row[] = [$c->red()->value(), $c->green()->value(), $c->blue()->value()];
+            }
+            $pixels[] = $row;
+        }
+        return \kornrunner\Blurhash\Blurhash::encode($pixels, 4, 4);
+    }
+}
+```
+
+Add `kornrunner/blurhash: ^1.0` to `composer.json` as `require-dev` (consumer can swap to a different generator).
+
+- [ ] **Step 3: Tests + commit**
+
+Test using a known JPEG fixture.
+
+```bash
+git add src/Storage/Extractors tests/Feature/Storage composer.json composer.lock
+git commit -m "feat(media-library): add default EXIF + blurhash + palette extractors"
+```
+
+---
+
+## Task 11: DefaultSubjectResolver + FolderPermissionResolver + MediaLibraryAccess
+
+**Files:**
+- Create: `src/Access/Support/{DefaultSubjectResolver, FolderPermissionResolver, MediaLibraryAccess}.php`
+- Tests under `tests/Feature/Access/`
+
+- [ ] **Step 1: DefaultSubjectResolver**
+
+```php
+namespace Kurt\Modules\MediaLibrary\Access\Support;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Kurt\Modules\MediaLibrary\Access\Contracts\MediaSubjectResolver;
+use Kurt\Modules\MediaLibrary\Access\Enums\SubjectType;
+use Kurt\Modules\MediaLibrary\Access\Values\Subject;
+use Kurt\Modules\MediaLibrary\Contracts\MediaLibraryOwner;
+use Kurt\Modules\MediaLibrary\Exceptions\OwnerNotResolved;
+
+final class DefaultSubjectResolver implements MediaSubjectResolver
+{
+    public function subjects(?Authenticatable $user): array
+    {
+        $subjects = [new Subject(SubjectType::Everyone, null)];
+        if ($user !== null) {
+            $subjects[] = new Subject(SubjectType::User, (string) $user->getAuthIdentifier());
+        }
+        return $subjects;
+    }
+
+    public function defaultOwner(?Authenticatable $user): MediaLibraryOwner
+    {
+        if (! $user instanceof MediaLibraryOwner) {
+            throw new OwnerNotResolved('Authenticated user does not implement MediaLibraryOwner');
+        }
+        return $user;
+    }
+}
+```
+
+- [ ] **Step 2: FolderPermissionResolver**
+
+Mirrors ResourceLibrary's algorithm. Walk ancestry, find highest matching capability per subject, fall back to folder visibility.
+
+- [ ] **Step 3: MediaLibraryAccess**
+
+Request-scoped cache keyed by `userId:folderId:capability`.
+
+- [ ] **Step 4: Exhaustive ACL matrix tests**
+
+Cascade × visibility × ancestor override × subject mismatch.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Access/Support tests/Feature/Access
+git commit -m "feat(media-library): add DefaultSubjectResolver + FolderPermissionResolver + MediaLibraryAccess"
+```
+
+---
+
+## Task 12: ShareLinkSigner + ShareLinkResolver + AccessLogger
+
+**Files:**
+- Create: `src/Sharing/Support/{ShareLinkSigner, ShareLinkResolver, AccessLogger}.php`
+- Tests under `tests/Feature/Sharing/`
+
+- [ ] **Step 1: ShareLinkSigner**
+
+```php
+final class ShareLinkSigner
+{
+    public function generateToken(): string
+    {
+        return rtrim(strtr(base64_encode(random_bytes(24)), '+/', '-_'), '=');
+    }
+
+    public function url(string $token): string
+    {
+        $prefix = trim((string) config('media-library.routes.share_prefix', 'media-library/share'), '/');
+        return url($prefix . '/' . $token);
+    }
+}
+```
+
+- [ ] **Step 2: ShareLinkResolver**
+
+```php
+final class ShareLinkResolver
+{
+    public function resolve(string $token): ShareLink
+    {
+        $link = ShareLink::query()->where('token', $token)->first();
+        if ($link === null) throw new ShareLinkInvalid('not_found');
+        if (! $link->isActive()) throw new ShareLinkInvalid('inactive');
+        return $link;
+    }
+}
+```
+
+- [ ] **Step 3: AccessLogger**
+
+```php
+final class AccessLogger
+{
+    public function log(?MediaLibraryItem $item, ?ShareLink $link, ?Model $user, AccessAction $action): void
+    {
+        if (! (bool) config('media-library.access_log.enabled', true)) return;
+        if ($action === AccessAction::View && ! (bool) config('media-library.access_log.on_view', true)) return;
+        if ($action === AccessAction::Download && ! (bool) config('media-library.access_log.on_download', true)) return;
+
+        $request = request();
+        AccessLogEntry::create([
+            'item_id' => $item?->id,
+            'share_link_id' => $link?->id,
+            'user_id' => $user?->getKey(),
+            'action' => $action,
+            'ip' => $request?->ip(),
+            'user_agent' => (string) $request?->userAgent(),
+            'occurred_at' => now(),
+        ]);
+    }
+}
+```
+
+- [ ] **Step 4: ShareLinkController**
+
+Route opt-in via `config('media-library.routes.share_enabled')`. Controller handles view + download. Increments `access_count`, sets `last_accessed_*`, writes access log.
+
+```php
+final class ShareLinkController
+{
+    public function __construct(
+        private readonly ShareLinkResolver $resolver,
+        private readonly AccessLogger $logger,
+    ) {}
+
+    public function show(string $token, Request $request)
+    {
+        $link = $this->resolver->resolve($token);
+        $abilities = (array) $link->abilities;
+        $requested = $request->query('download') ? 'download' : 'view';
+
+        if (! in_array($requested, $abilities, true)) {
+            abort(403, 'ability_not_granted');
+        }
+
+        $link->forceFill([
+            'access_count' => $link->access_count + 1,
+            'last_accessed_at' => now(),
+            'last_accessed_ip' => $request->ip(),
+        ])->save();
+
+        $this->logger->log($link->item, $link, $request->user(), AccessAction::from($requested));
+
+        $media = $link->item?->spatieMedia();
+        if ($media === null) abort(410, 'media_gone');
+
+        return $requested === 'download'
+            ? response()->download($media->getPath(), $media->file_name)
+            : response()->file($media->getPath());
+    }
+}
+```
+
+`routes/share.php`:
+
+```php
+<?php
+
+use Illuminate\Support\Facades\Route;
+use Kurt\Modules\MediaLibrary\Sharing\Http\Controllers\ShareLinkController;
+
+Route::middleware('web')
+    ->prefix((string) config('media-library.routes.share_prefix', 'media-library/share'))
+    ->group(function () {
+        Route::get('{token}', [ShareLinkController::class, 'show'])->name('media-library.share.show');
+    });
+```
+
+The service provider conditionally requires this file when `config('media-library.routes.share_enabled')` is true.
+
+- [ ] **Step 5: Tests + commit**
+
+Tests cover: token generation uniqueness; resolver throws for missing/revoked/expired; controller streams + logs.
+
+```bash
+git add src/Sharing tests/Feature/Sharing routes/share.php
+git commit -m "feat(media-library): add ShareLinkSigner + Resolver + AccessLogger + share controller"
+```
+
+---
+
+## Task 13: UploadCoordinator (server proxy)
+
+**Files:**
+- Create: `src/Storage/Support/{UploadCoordinator, MetadataExtractor}.php`
+- Tests under `tests/Feature/Storage/Upload/`
+
+- [ ] **Step 1: MetadataExtractor**
+
+Extracts dimensions (Intervention), dominant_color + palette + blurhash via bound contracts.
+
+```php
+final class MetadataExtractor
+{
+    public function __construct(
+        private readonly BlurhashGenerator $blurhash,
+        private readonly PaletteExtractor $palette,
+    ) {}
+
+    /** @return array<string, mixed> */
+    public function extractSync(string $path, string $mimeType): array
+    {
+        $meta = ['width' => null, 'height' => null];
+        if (str_starts_with($mimeType, 'image/')) {
+            try {
+                $manager = new \Intervention\Image\ImageManager(new \Intervention\Image\Drivers\Gd\Driver());
+                $img = $manager->read($path);
+                $meta['width'] = $img->width();
+                $meta['height'] = $img->height();
+                $meta['blurhash'] = $this->blurhash->generate($path);
+                $palette = $this->palette->extract($path);
+                $meta['dominant_color'] = $palette['dominant'] ?? null;
+                $meta['palette'] = $palette['palette'] ?? [];
+            } catch (\Throwable) {
+                // best-effort; leave nulls
+            }
+        }
+        return $meta;
+    }
+}
+```
+
+- [ ] **Step 2: UploadCoordinator**
+
+```php
+final class UploadCoordinator
+{
+    public function __construct(
+        private readonly MediaSubjectResolver $subjects,
+        private readonly MetadataExtractor $extractor,
+    ) {}
+
+    public function upload(UploadedFile $file, ?MediaLibraryOwner $owner, ?MediaLibraryFolder $folder = null, array $attributes = []): MediaLibraryItem
+    {
+        $owner ??= $this->subjects->defaultOwner(auth()->user());
+
+        return DB::transaction(function () use ($file, $owner, $folder, $attributes) {
+            $storage = MediaLibraryStorage::create(['item_uid' => (string) Str::uuid()]);
+            $media = $storage->addMedia($file->getPathname())
+                ->preservingOriginal()
+                ->usingFileName($file->getClientOriginalName())
+                ->toMediaCollection('mli', (string) config('media-library.uploads.disk', 'public'));
+
+            $extracted = $this->extractor->extractSync($media->getPath(), $media->mime_type);
+
+            $title = $attributes['title'] ?? ['en' => $file->getClientOriginalName()];
+            $item = MediaLibraryItem::create([
+                'owner_type' => $owner->getMorphClass(),
+                'owner_id' => $owner->getKey(),
+                'folder_id' => $folder?->id,
+                'storage_id' => $storage->id,
+                'slug' => Str::slug((string) ($attributes['slug'] ?? $file->getClientOriginalName())) . '-' . substr($storage->item_uid, 0, 8),
+                'title' => $title,
+                'alt_text' => $attributes['alt_text'] ?? null,
+                'caption' => $attributes['caption'] ?? null,
+                'description' => $attributes['description'] ?? null,
+                'filename' => $file->getClientOriginalName(),
+                'mime_type' => $media->mime_type,
+                'byte_size' => $media->size,
+                'width' => $extracted['width'] ?? null,
+                'height' => $extracted['height'] ?? null,
+                'dominant_color' => $extracted['dominant_color'] ?? null,
+                'palette' => $extracted['palette'] ?? null,
+                'blurhash' => $extracted['blurhash'] ?? null,
+                'created_by' => auth()->id(),
+                'updated_by' => auth()->id(),
+            ]);
+
+            if ($folder !== null) {
+                $folder->increment('item_count');
+            }
+
+            ItemUploaded::dispatch($item);
+
+            return $item;
+        });
+    }
+}
+```
+
+- [ ] **Step 3: Tests + commit**
+
+Server-proxy upload happy path with PNG fixture. Asserts item persisted, spatie media attached, dimensions extracted, dispatched event.
+
+```bash
+git add src/Storage/Support tests
+git commit -m "feat(media-library): add MetadataExtractor + UploadCoordinator (server proxy)"
+```
+
+---
+
+## Task 14: Presigned upload flow
+
+**Files:**
+- Extend `src/Storage/Support/UploadCoordinator.php` with `initiateUpload` + `completeUpload` + `cancelUpload`
+- Tests under `tests/Feature/Storage/PresignedUpload/`
+
+- [ ] **Step 1: initiateUpload**
+
+Validates mime + size against config. Generates presigned PUT URL via `Storage::disk(config('media-library.uploads.disk'))->temporaryUploadUrl(...)`. Persists `media_library_pending_uploads` row.
+
+- [ ] **Step 2: completeUpload**
+
+Look up pending row + verify status. Attach the already-on-disk object as the spatie Media file. Run extractor pipeline. Persist item. Mark pending Completed.
+
+- [ ] **Step 3: cancelUpload**
+
+Mark pending Cancelled.
+
+- [ ] **Step 4: Tests**
+
+Cover initiate happy path, complete happy path, cancel, expired pending. Use a fake disk for S3-style storage simulation (`Storage::fake('s3')`).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Storage/Support tests
+git commit -m "feat(media-library): add presigned direct-to-S3 upload via UploadCoordinator"
+```
+
+---
+
+## Task 15: ConversionEngine + FocalPointCropper + VariantGenerator
+
+**Files:**
+- Create: `src/Storage/Support/{ConversionEngine, FocalPointCropper, VariantGenerator}.php`
+
+- [ ] **Step 1: FocalPointCropper**
+
+Translates focal_x/focal_y + target dimensions into a crop rectangle. Returns coordinates compatible with spatie's `manualCrop`.
+
+```php
+final class FocalPointCropper
+{
+    /** @return array{x: int, y: int, width: int, height: int} */
+    public function compute(int $sourceWidth, int $sourceHeight, int $targetWidth, int $targetHeight, float $focalX, float $focalY): array
+    {
+        $sourceRatio = $sourceWidth / max($sourceHeight, 1);
+        $targetRatio = $targetWidth / max($targetHeight, 1);
+
+        if ($sourceRatio > $targetRatio) {
+            $cropHeight = $sourceHeight;
+            $cropWidth = (int) round($sourceHeight * $targetRatio);
+        } else {
+            $cropWidth = $sourceWidth;
+            $cropHeight = (int) round($sourceWidth / $targetRatio);
+        }
+
+        $cx = (int) round($focalX * $sourceWidth);
+        $cy = (int) round($focalY * $sourceHeight);
+        $x = max(0, min($sourceWidth - $cropWidth, $cx - intdiv($cropWidth, 2)));
+        $y = max(0, min($sourceHeight - $cropHeight, $cy - intdiv($cropHeight, 2)));
+
+        return ['x' => $x, 'y' => $y, 'width' => $cropWidth, 'height' => $cropHeight];
+    }
+}
+```
+
+- [ ] **Step 2: VariantGenerator**
+
+```php
+final class VariantGenerator
+{
+    public function __construct(private readonly FocalPointCropper $cropper) {}
+
+    public function generateOrFetch(MediaLibraryItem $item, array $spec): MediaLibraryVariant
+    {
+        $key = $this->canonicalizeKey($spec);
+        $existing = MediaLibraryVariant::query()->where('item_id', $item->id)->where('key', $key)->first();
+        if ($existing !== null) {
+            $existing->forceFill(['last_used_at' => now()])->save();
+            return $existing;
+        }
+
+        $sourcePath = $item->spatieMedia()?->getPath();
+        if ($sourcePath === null) throw new \RuntimeException('item has no source media');
+
+        $disk = (string) config('media-library.uploads.disk', 'public');
+        $variantRelative = 'media-library/variants/' . $item->storage->item_uid . '/' . $key . '.' . ($spec['format'] ?? 'jpg');
+        $variantFull = Storage::disk($disk)->path($variantRelative);
+        @mkdir(dirname($variantFull), recursive: true);
+
+        $manager = new \Intervention\Image\ImageManager(new \Intervention\Image\Drivers\Gd\Driver());
+        $img = $manager->read($sourcePath);
+        $fit = $spec['fit'] ?? 'fit';
+        $width = (int) ($spec['width'] ?? $img->width());
+        $height = (int) ($spec['height'] ?? $img->height());
+
+        if ($fit === 'crop') {
+            $crop = $this->cropper->compute($img->width(), $img->height(), $width, $height, (float) $item->focal_x, (float) $item->focal_y);
+            $img = $img->crop($crop['width'], $crop['height'], $crop['x'], $crop['y'])->resize($width, $height);
+        } else {
+            $img = $img->scaleDown($width, $height);
+        }
+
+        $quality = (int) ($spec['quality'] ?? 85);
+        $img->save($variantFull, $quality);
+
+        return MediaLibraryVariant::create([
+            'item_id' => $item->id,
+            'key' => $key,
+            'spec' => $spec,
+            'path' => $variantRelative,
+            'mime_type' => mime_content_type($variantFull) ?: 'application/octet-stream',
+            'byte_size' => filesize($variantFull) ?: 0,
+            'last_used_at' => now(),
+            'generated_at' => now(),
+        ]);
+    }
+
+    private function canonicalizeKey(array $spec): string
+    {
+        ksort($spec);
+        return implode('-', [
+            ($spec['width'] ?? 'auto') . 'x' . ($spec['height'] ?? 'auto'),
+            $spec['fit'] ?? 'fit',
+            $spec['format'] ?? 'jpg',
+            'q' . ($spec['quality'] ?? 85),
+        ]);
+    }
+}
+```
+
+- [ ] **Step 3: ConversionEngine**
+
+Stub for now — preset conversions live on the `MediaLibraryStorage` host (spatie handles them). This class is just a thin wrapper that translates `MediaLibraryItem::url($conversion)` calls.
+
+- [ ] **Step 4: Tests + commit**
+
+Tests cover: focal corner math, ad-hoc variant generation, cache hit on second call, key canonicalization.
+
+```bash
+git add src/Storage/Support tests
+git commit -m "feat(media-library): add ConversionEngine + FocalPointCropper + VariantGenerator"
+```
+
+---
+
+## Task 16: ReplaceCoordinator
+
+**Files:**
+- Create: `src/Storage/Support/ReplaceCoordinator.php`
+- Test under `tests/Feature/Storage/ReplaceTest.php`
+
+- [ ] **Step 1: ReplaceCoordinator**
+
+Per spec §9. Atomic transaction: capture previous spatie Media id, write version row, attach new file, swap storage's spatie media, recompute extractors, regenerate conversions, dispatch ItemReplaced.
+
+- [ ] **Step 2: Tests**
+
+Confirm stable item id after replace; attachment rows preserved; version row exists with previous spatie media id; ItemReplaced event dispatched.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Storage/Support/ReplaceCoordinator.php tests
+git commit -m "feat(media-library): add ReplaceCoordinator with version history + stable item id"
+```
+
+---
+
+## Task 17: Domain events
+
+**Files:**
+- Create: under `src/Catalog/Events/`, `src/Storage/Events/`, `src/Sharing/Events/`, `src/Access/Events/`
+
+Per spec §22. Each uses `Illuminate\Foundation\Events\Dispatchable`.
+
+Bulk creation:
+
+- Catalog: `FolderCreated/Updated/Moved/Deleted/Restored/PermissionChanged`, `ItemUploaded/Updated/Replaced/Attached/Detached/Tagged/Untagged/Trashed/Restored/Deleted/Viewed/Downloaded`.
+- Storage: `UploadInitiated/Completed/Cancelled/Expired`, `VariantGenerated`, `VersionPruned`, `BlurhashComputed/PaletteComputed/ExifExtracted/AiTagsAssigned/TextExtracted`.
+- Sharing: `ShareLinkCreated/Accessed/Revoked/Expired`.
+
+Single-arg events: one readonly promoted property. Multi-arg as needed (e.g. `ItemReplaced(MediaLibraryItem $item, int $previousSpatieMediaId)`).
+
+- [ ] **Step 1: Write all event classes**
+- [ ] **Step 2: Commit**
+
+```bash
+git add src
+git commit -m "feat(media-library): add domain events across sub-areas"
+```
+
+---
+
+## Task 18: Observers
+
+**Files:**
+- Create: `src/Catalog/Observers/{MediaLibraryItemObserver, MediaLibraryFolderObserver}.php`
+
+- [ ] **Step 1: MediaLibraryItemObserver**
+
+```php
+final class MediaLibraryItemObserver
+{
+    public function deleted(MediaLibraryItem $item): void
+    {
+        if ($item->folder_id !== null) {
+            DB::table('media_library_folders')
+                ->where('id', $item->folder_id)
+                ->update(['item_count' => DB::raw('CASE WHEN item_count > 0 THEN item_count - 1 ELSE 0 END')]);
+        }
+        ItemDeleted::dispatch($item);
+    }
+
+    public function restored(MediaLibraryItem $item): void
+    {
+        if ($item->folder_id !== null) {
+            DB::table('media_library_folders')->where('id', $item->folder_id)->increment('item_count');
+        }
+        ItemRestored::dispatch($item);
+    }
+}
+```
+
+- [ ] **Step 2: MediaLibraryFolderObserver**
+
+```php
+final class MediaLibraryFolderObserver
+{
+    public function creating(MediaLibraryFolder $folder): void
+    {
+        if (! $folder->path) {
+            $parentPath = $folder->parent?->path ?? '';
+            $folder->path = $parentPath . '/' . $folder->slug;
+            $folder->depth = ($folder->parent?->depth ?? -1) + 1;
+        }
+    }
+
+    public function created(MediaLibraryFolder $folder): void
+    {
+        FolderCreated::dispatch($folder);
+    }
+
+    public function deleted(MediaLibraryFolder $folder): void
+    {
+        FolderDeleted::dispatch($folder);
+    }
+}
+```
+
+- [ ] **Step 3: Tests + commit**
+
+```bash
+git add src/Catalog/Observers tests
+git commit -m "feat(media-library): add Folder + Item observers"
+```
+
+---
+
+## Task 19: Policies
+
+**Files:**
+- Create: `src/Policies/{MediaLibraryItemPolicy, MediaLibraryFolderPolicy, ShareLinkPolicy, SavedSearchPolicy}.php`
+
+Each delegates to `MediaLibraryAccess::check`. Tests verify allow/deny per matrix per spec §18.
+
+- [ ] **Step 1: Write each policy + tests**
+- [ ] **Step 2: Commit**
+
+```bash
+git add src/Policies tests/Feature/Policies
+git commit -m "feat(media-library): add policies"
+```
+
+---
+
+## Task 20: Console commands
+
+**Files:**
+- Create: `src/Console/Commands/{PruneVersions, PruneVariants, RebuildPaths, Recount, ExpireShares, PruneShares, ExpirePendingUploads, Reextract, Reindex, Demo}Command.php`
+
+Per spec §20. Each is a small Command.
+
+Highlights:
+
+```php
+// PruneVersionsCommand
+protected $signature = 'media-library:prune-versions {item?}';
+public function handle(): int
+{
+    $keepNewest = (int) config('media-library.versions.keep_old', 10);
+    $items = $this->argument('item') ? MediaLibraryItem::query()->whereKey($this->argument('item'))->get() : MediaLibraryItem::all();
+    foreach ($items as $item) {
+        $versions = $item->versions()->orderByDesc('created_at')->skip($keepNewest)->take(1000)->get();
+        foreach ($versions as $version) $version->delete();
+    }
+    return self::SUCCESS;
+}
+```
+
+```php
+// ExpirePendingUploadsCommand
+public function handle(): int
+{
+    MediaLibraryPendingUpload::query()
+        ->where('status', PendingUploadStatus::Pending->value)
+        ->where('expires_at', '<', now())
+        ->update(['status' => PendingUploadStatus::Expired->value]);
+    return self::SUCCESS;
+}
+```
+
+- [ ] **Step 1: Write each command**
+- [ ] **Step 2: Tests for non-trivial commands**
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Console tests/Feature/Console
+git commit -m "feat(media-library): add console commands"
+```
+
+---
+
+## Task 21: Notifications + Blade templates
+
+**Files:**
+- Create: `src/Notifications/{ShareLinkCreated, ShareLinkAccessed, ItemReplaced, LargeUploadCompleted}.php`
+- Create: `resources/views/notifications/*.blade.php`
+
+Each Notification implements `ShouldQueue`, uses `via(['mail', 'database'])` when notifications enabled in config.
+
+- [ ] **Step 1: Each Notification class + Blade template**
+- [ ] **Step 2: Tests with `Notification::fake()`**
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/Notifications resources/views tests
+git commit -m "feat(media-library): add optional Notifications + default Blade templates"
+```
+
+---
+
+## Task 22: Top-level MediaLibrary facade-service
+
+**Files:**
+- Create: `src/Support/MediaLibrary.php`
+- Create: `src/Facades/MediaLibrary.php`
+
+Implements every method from spec §16. Delegates to UploadCoordinator / ReplaceCoordinator / ShareLinkSigner / etc.
+
+- [ ] **Step 1: Write facade-service**
+- [ ] **Step 2: Thin Facade class**
+
+```php
+namespace Kurt\Modules\MediaLibrary\Facades;
+
+use Illuminate\Support\Facades\Facade;
+use Kurt\Modules\MediaLibrary\Support\MediaLibrary as Service;
+
+final class MediaLibrary extends Facade
+{
+    protected static function getFacadeAccessor(): string { return Service::class; }
+}
+```
+
+- [ ] **Step 3: Tests covering top-level API**
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Support src/Facades tests
+git commit -m "feat(media-library): add top-level MediaLibrary facade-service"
+```
+
+---
+
+## Task 23: MediaLibraryServiceProvider
+
+**Files:**
+- Create: `src/Providers/MediaLibraryServiceProvider.php`
+
+Per the pattern used in Events/Chat providers. Highlights:
+
+- `configurePackage`: name, hasConfigFile('media-library'), hasTranslations, hasViews('media-library'), hasMigrations(every filename), hasCommands(all 10).
+- `packageRegistered`: bind `MediaSubjectResolver`, `ScoutAdapter` (if FQCN bound), `ExifExtractor`/`BlurhashGenerator`/`PaletteExtractor`/`OcrExtractor`/`AiTagger` from config. Singleton bindings for UploadCoordinator, ReplaceCoordinator, VariantGenerator, FolderPermissionResolver, MediaLibraryAccess, ShareLinkSigner, ShareLinkResolver, AccessLogger. Singleton for `Support\MediaLibrary`.
+- `packageBooted`: observe Folder + Item, register policies, conditionally load `routes/share.php`, schedule commands.
+
+- [ ] **Step 1: Write provider**
+- [ ] **Step 2: Update `tests/TestCase.php`**
+
+```php
+protected function modulePackageProviders($app): array
+{
+    return [
+        \Spatie\MediaLibrary\MediaLibraryServiceProvider::class,
+        \Cviebrock\EloquentSluggable\ServiceProvider::class,
+        \Kurt\Modules\MediaLibrary\Providers\MediaLibraryServiceProvider::class,
+    ];
+}
+```
+
+- [ ] **Step 3: Smoke tests + commit**
+
+```bash
+git add src/Providers tests
+git commit -m "feat(media-library): add MediaLibraryServiceProvider"
+```
+
+---
+
+## Task 24: Cross-cutting integration tests
+
+**Files:**
+- Create: `tests/Feature/Integration/*.php`
+
+Tests covering scenarios that thread multiple sub-areas:
+
+- `UploadAndAttachTest.php`: upload → attach to Post (HasMediaLibraryItems trait stub) → retrieve via `mediaItems('cover')`.
+- `ReplaceKeepsAttachmentsTest.php`: attach item to multiple consumer rows → replace file → consumers still resolve.
+- `FolderMoveCascadesPathsTest.php`: nested folder move rewrites descendant paths.
+- `AclMatrixTest.php`: cascade × visibility × subject mismatch.
+- `ShareEndToEndTest.php`: shareItem → access via controller → access log row + counter.
+- `PresignedUploadFlowTest.php`: initiate → complete → item issued.
+- `VariantCacheHitTest.php`: variant(spec) twice → second call hits cache, first uses generator.
+- `GdprAnonymizationTest.php`: anonymize user → owner fields preserved as morph but display strings hashed.
+
+- [ ] **Step 1: Write each test**
+- [ ] **Step 2: Commit**
+
+```bash
+git add tests/Feature/Integration
+git commit -m "test(media-library): add cross-cutting integration tests"
+```
+
+Expected: ~250-300 total tests.
+
+---
+
+## Task 25: CI + README + CHANGELOG + UPGRADE-1.0
+
+**Files:**
+- Copy: `.github/workflows/tests.yml`, `.github/dependabot.yml` from Events.
+- Create: `README.md`, `CHANGELOG.md`, `UPGRADE-1.0.md`.
+
+- [ ] **Step 1: Copy CI**
+
+```bash
+cp ../KurtModules-Events/.github/workflows/tests.yml .github/workflows/tests.yml
+cp ../KurtModules-Events/.github/dependabot.yml .github/dependabot.yml
+```
+
+- [ ] **Step 2: README.md**
+
+```markdown
+# laravel-modules-media-library
+
+WordPress-style media bucket for Laravel SaaS: tenant-aware folders, polymorphic attachments, focal-point conversions, replace-with-stable-id versioning, share links, folder ACL.
+
+Wraps `spatie/laravel-medialibrary` as the storage engine.
+
+## Requirements
+
+- PHP 8.4+
+- Laravel 12.x
+- `ozankurt/laravel-modules-core` v2.x
+- `spatie/laravel-medialibrary` v11.x
+
+## Installation
+
+```bash
+composer require ozankurt/laravel-modules-media-library
+php artisan vendor:publish --tag=media-library-config
+php artisan vendor:publish --tag=media-library-migrations
+php artisan migrate
+```
+
+## What it provides
+
+- **Catalog** — MediaLibraryFolder (nested tree), MediaLibraryItem (WordPress-style row), MediaLibraryTag, polymorphic attachments to consumer models, saved searches.
+- **Storage** — Wraps spatie/laravel-medialibrary via a per-item host model. Versioning with stable item ids. Ad-hoc focal-point-aware variant generation. Presigned direct-to-S3 + server-proxy upload flows.
+- **Sharing** — TTL share links with abilities (view/download) + access log + invitee email.
+- **Access** — Folder ACL with the same SubjectResolver pattern as ResourceLibrary.
+- **Search** — Eloquent scopes (byOwner/byFolder/byTag/byMimeType/byDateRange/search) + optional Scout adapter contract.
+- **Pluggable contracts** — EXIF, OCR, AI tagger, blurhash, palette extractor, Scout adapter, MediaSubjectResolver.
+- **Optional Laravel Notifications** — Mail + Database channels with publishable Blade templates.
+
+## Filament admin
+
+Filament v3/v4/v5 admin (WordPress-style grid + edit modal) lands in v1.1.
+
+## License
+
+MIT © Ozan Kurt
+```
+
+- [ ] **Step 3: CHANGELOG.md**
+
+```markdown
+# Changelog
+
+## [1.0.0] - 2026-05-30
+
+### Added
+- Initial release of `ozankurt/laravel-modules-media-library`.
+- 13 migrations across Catalog / Storage / Sharing / Access.
+- `MediaLibraryItem` + `MediaLibraryStorage` host pattern that wraps spatie/laravel-medialibrary as the storage engine.
+- Polymorphic owner (User/Team/Organization).
+- Polymorphic many-to-many attachments to consumer models with role + position.
+- Nested folder tree + per-folder ACL (same shape as ResourceLibrary).
+- WordPress-style metadata fields: title, alt_text, caption, description, focal_x/y, dominant_color, palette, blurhash, exif, ai_tags, extracted_text.
+- Named-preset + ad-hoc focal-point-aware conversions.
+- Server-proxy AND direct-to-S3 presigned uploads.
+- Replace-in-place with stable item id + version history (`media_library_versions`).
+- Share links with TTL + abilities + access log.
+- Tag taxonomy + saved searches per user.
+- Pluggable extractor contracts (EXIF / OCR / AI tagger / blurhash / palette / Scout adapter / MediaSubjectResolver).
+- Default extractors shipped: EXIF (PHP exif), Blurhash (kornrunner), Palette (Intervention).
+- Console commands: prune-versions, prune-variants, rebuild-paths, recount, expire-shares, prune-shares, expire-pending-uploads, reextract, reindex, demo.
+- Optional Laravel Notifications + default Blade templates.
+
+### Planned (v1.1)
+- Filament v3/v4/v5 admin resources.
+- Default Scout adapter.
+- Promote cross-module audit log into a shared package.
+```
+
+- [ ] **Step 4: UPGRADE-1.0.md (initial release stub)**
+
+```markdown
+# Upgrade Guide — initial release
+
+This is v1.0.0 of `ozankurt/laravel-modules-media-library`. There is no previous version to upgrade from.
+
+## Installation
+
+See `README.md`. Key environment knobs:
+
+- `MEDIA_LIBRARY_DISK` — default `public`.
+
+## Future upgrades
+
+This file will document migration steps for v2.0 and beyond.
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github README.md CHANGELOG.md UPGRADE-1.0.md
+git commit -m "ci+docs: add github actions, README, CHANGELOG, UPGRADE-1.0"
+```
+
+---
+
+## Task 26: Push + PR + merge + tag
+
+- [ ] **Step 1: Final local verification**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pint --test
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/phpstan analyse --memory-limit=2G
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pest
+```
+
+All three green. ~250+ tests.
+
+- [ ] **Step 2: Push + PR**
+
+```bash
+git push -u origin v1.0
+gh pr create --title "v1.0: initial release of ozankurt/laravel-modules-media-library" --body "$(cat <<'EOF'
+## Summary
+
+- Greenfield WordPress-style media bucket for Laravel SaaS.
+- 13 tables across Catalog / Storage / Sharing / Access.
+- Wraps spatie/laravel-medialibrary as the storage engine via a thin per-item host model.
+- Polymorphic owner + polymorphic many-to-many attachments.
+- Replace-with-stable-id versioning so consumer attachments survive file swaps.
+- Server-proxy + direct-to-S3 presigned uploads.
+- Focal-point-aware conversions + ad-hoc variant cache.
+- Share links with TTL + access log.
+- Folder ACL reusing ResourceLibrary's SubjectResolver pattern.
+- Pluggable contracts for EXIF / OCR / AI / blurhash / palette / Scout / subject resolver.
+- Filament admin lands in v1.1.
+
+## Test plan
+- [x] vendor/bin/pint --test
+- [x] vendor/bin/phpstan analyse
+- [x] vendor/bin/pest
+- [ ] CI matrix green on this PR
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI green, merge, tag, release**
+
+```bash
+gh pr checks <PR_NUMBER> --watch
+gh pr merge <PR_NUMBER> --merge
+git switch master
+git pull
+git tag -a v1.0.0 -m "v1.0.0"
+git push origin v1.0.0
+gh release create v1.0.0 --title "v1.0.0" --notes-file CHANGELOG.md
+```
+
+---
+
+## Definition of done
+
+- [ ] All 13 migrations applied; smoke test confirms every table present.
+- [ ] Server-proxy + presigned upload paths covered.
+- [ ] Replace flow proves stable item id + attachment preservation.
+- [ ] Conversion presets + ad-hoc variants + focal cropping all tested.
+- [ ] Folder ACL matrix exhaustive.
+- [ ] Share-link controller end-to-end with access log.
+- [ ] All commands behave per spec §20.
+- [ ] Pint + PHPStan level 8 + Pest pass.
+- [ ] CI matrix green.
+- [ ] README + CHANGELOG + UPGRADE-1.0 in place.
+- [ ] Tagged `v1.0.0`; GitHub release published.

--- a/docs/superpowers/plans/2026-05-30-kurtmodules-resource-library-rename-v3.md
+++ b/docs/superpowers/plans/2026-05-30-kurtmodules-resource-library-rename-v3.md
@@ -1,0 +1,801 @@
+# `ozankurt/laravel-modules-resource-library` v3.0 — Rename Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Rename the existing `ozankurt/laravel-modules-library` v2 package to `ozankurt/laravel-modules-resource-library` v3.0.0 — namespace, composer name, provider class, config key, console signatures, and table prefix all change from `library*` to `resource_library*`. No functional behavior changes.
+
+**Architecture:** Mechanical rename across the entire repo via a sequence of search-and-replace passes + one new migration that runs `Schema::rename(...)` on every existing table. The repo on GitHub keeps its current URL (`KurtModules-Library`) — only the composer name, classes, configs, and tables change.
+
+**Tech Stack:** PHP 8.4, Laravel 12, Pest 3 + Testbench, PHPStan 8, Pint. Same stack as v2 — no dep changes.
+
+**Spec:** [2026-05-30-kurtmodules-resource-library-rename-spec.md](../specs/2026-05-30-kurtmodules-resource-library-rename-spec.md)
+
+**Working directory:** `D:\Code\Projects\KurtModules-Library`. Branch `v3.0` off `master`.
+
+---
+
+## File-by-file rename inventory
+
+Before writing tasks, here's exactly what each file becomes:
+
+```
+composer.json                                          (edit: name, autoload, provider)
+config/library.php                            ->       config/resource-library.php
+src/Providers/LibraryServiceProvider.php      ->       src/Providers/ResourceLibraryServiceProvider.php
+src/Facades/Library.php                        ->       src/Facades/ResourceLibrary.php   (if it exists)
+src/Console/Commands/RecountCommand.php                (edit: $signature 'library:recount' -> 'resource-library:recount')
+src/Console/Commands/PruneVersionsCommand.php          (edit: 'library:prune-versions' -> 'resource-library:prune-versions')
+src/Console/Commands/RebuildPathsCommand.php           (edit: 'library:rebuild-paths' -> 'resource-library:rebuild-paths')
+src/Console/Commands/DemoCommand.php                   (edit: 'library:demo' -> 'resource-library:demo')
+src/<every PHP file>                                   (namespace: Kurt\Modules\Library\ -> Kurt\Modules\ResourceLibrary\)
+database/factories/<all>                               (namespace: Database\Factories\Kurt\Modules\Library -> Database\Factories\Kurt\Modules\ResourceLibrary)
+tests/<every PHP file>                                 (namespace + assertion strings)
+tests/TestCase.php                                     (provider FQCN)
+tests/Pest.php                                         (TestCase FQCN)
+README.md                                              (rewrite for v3)
+CHANGELOG.md                                           (prepend v3.0.0 entry)
+UPGRADE-3.0.md                                         (new — consumer migration steps)
+
+database/migrations/2026_05_30_NNNNNN_rename_library_to_resource_library.php   (new migration)
+```
+
+---
+
+## Task 0: Branch setup
+
+**Files:**
+- None created/modified yet. Just branch ops.
+
+- [ ] **Step 1: Create v3.0 branch off master**
+
+```bash
+cd D:/Code/Projects/KurtModules-Library
+git fetch --all --prune
+git switch master
+git pull
+git switch -c v3.0
+```
+
+- [ ] **Step 2: Verify v2.0.0 tag exists (sanity)**
+
+```bash
+git tag -l v2.0.0
+```
+Expected: `v2.0.0` is listed.
+
+---
+
+## Task 1: composer.json rename
+
+**Files:**
+- Modify: `composer.json`
+
+- [ ] **Step 1: Read current composer.json to find replacement targets**
+
+```bash
+cat composer.json
+```
+
+- [ ] **Step 2: Apply rename edits**
+
+Replace these exact strings:
+
+- `"ozankurt/laravel-modules-library"` → `"ozankurt/laravel-modules-resource-library"`
+- `"description"` value updated: `"SaaS resource library: nested folders with per-folder permissions, versioned items (video link, file, document, URL)."` (description stays — already accurate).
+- In `autoload.psr-4`: `"Kurt\\Modules\\Library\\": "src/"` → `"Kurt\\Modules\\ResourceLibrary\\": "src/"`
+- In `autoload-dev.psr-4`: 
+  - `"Kurt\\Modules\\Library\\Tests\\": "tests/"` → `"Kurt\\Modules\\ResourceLibrary\\Tests\\": "tests/"`
+  - `"Database\\Factories\\Kurt\\Modules\\Library\\": "database/factories/"` → `"Database\\Factories\\Kurt\\Modules\\ResourceLibrary\\": "database/factories/"`
+- In `extra.laravel.providers`: `"Kurt\\Modules\\Library\\Providers\\LibraryServiceProvider"` → `"Kurt\\Modules\\ResourceLibrary\\Providers\\ResourceLibraryServiceProvider"`
+
+- [ ] **Step 3: Validate composer.json**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe composer.phar validate --strict
+```
+Expected: `./composer.json is valid`.
+
+- [ ] **Step 4: Regenerate autoload**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe composer.phar dump-autoload
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add composer.json composer.lock
+git commit -m "chore: rename composer package to ozankurt/laravel-modules-resource-library"
+```
+
+---
+
+## Task 2: PHP namespace rename across `src/`
+
+**Files:**
+- Modify: every file under `src/` (mass `sed`).
+
+- [ ] **Step 1: Confirm current namespace shape**
+
+```bash
+grep -rl "Kurt\\\\Modules\\\\Library" src/
+```
+Expected: list of all PHP files under `src/`.
+
+- [ ] **Step 2: Mass replace namespace declarations**
+
+Run from repo root:
+
+```bash
+find src -name '*.php' -exec sed -i 's/Kurt\\\\Modules\\\\Library/Kurt\\\\Modules\\\\ResourceLibrary/g' {} +
+find src -name '*.php' -exec sed -i 's/namespace Kurt\\\\Modules\\\\Library/namespace Kurt\\\\Modules\\\\ResourceLibrary/g' {} +
+```
+
+PowerShell alternative if `sed` unavailable:
+```powershell
+Get-ChildItem -Path src -Recurse -Filter *.php | ForEach-Object {
+    (Get-Content $_.FullName -Raw) -replace 'Kurt\\Modules\\Library', 'Kurt\Modules\ResourceLibrary' | Set-Content $_.FullName -NoNewline
+}
+```
+
+- [ ] **Step 3: Verify replacement was clean**
+
+```bash
+grep -r "Kurt\\\\Modules\\\\Library" src/ || echo "clean"
+```
+Expected: `clean` (or no matches).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src
+git commit -m "chore: rename namespace Kurt\Modules\Library to Kurt\Modules\ResourceLibrary in src/"
+```
+
+---
+
+## Task 3: Service provider class rename
+
+**Files:**
+- Rename: `src/Providers/LibraryServiceProvider.php` → `src/Providers/ResourceLibraryServiceProvider.php`
+- Modify: the class name inside
+
+- [ ] **Step 1: Verify file exists**
+
+```bash
+ls src/Providers/LibraryServiceProvider.php
+```
+
+- [ ] **Step 2: Git rename the file**
+
+```bash
+git mv src/Providers/LibraryServiceProvider.php src/Providers/ResourceLibraryServiceProvider.php
+```
+
+- [ ] **Step 3: Update class name inside**
+
+Replace `class LibraryServiceProvider` with `class ResourceLibraryServiceProvider` in the renamed file.
+
+Also update the Spatie package name passed to `configurePackage`:
+
+```php
+// before
+$package->name('laravel-modules-library')
+// after
+$package->name('laravel-modules-resource-library')
+```
+
+And the `hasConfigFile()` argument:
+```php
+// before
+->hasConfigFile()                  // implies config/library.php
+// after
+->hasConfigFile('resource-library') // explicitly load config/resource-library.php
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Providers
+git commit -m "chore: rename LibraryServiceProvider to ResourceLibraryServiceProvider"
+```
+
+---
+
+## Task 4: Config file rename
+
+**Files:**
+- Rename: `config/library.php` → `config/resource-library.php`
+- Modify: model FQCNs inside (already done in Task 2 via namespace sed, but double-check)
+
+- [ ] **Step 1: Git rename**
+
+```bash
+git mv config/library.php config/resource-library.php
+```
+
+- [ ] **Step 2: Verify model FQCNs were updated by the namespace sed**
+
+```bash
+grep "Kurt\\\\Modules\\\\Library" config/resource-library.php || echo "clean"
+```
+Expected: clean (Task 2 already replaced these).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add config
+git commit -m "chore: rename config/library.php to config/resource-library.php"
+```
+
+---
+
+## Task 5: Console command signatures
+
+**Files:**
+- Modify: every command class under `src/Console/Commands/`
+
+- [ ] **Step 1: List all commands + current signatures**
+
+```bash
+grep -rE "protected \$signature = 'library:" src/Console/Commands/
+```
+
+- [ ] **Step 2: Replace `library:` prefix with `resource-library:` in every signature**
+
+Bash:
+```bash
+find src/Console/Commands -name '*.php' -exec sed -i "s/protected \\\$signature = 'library:/protected \\\$signature = 'resource-library:/g" {} +
+```
+
+PowerShell:
+```powershell
+Get-ChildItem -Path src/Console/Commands -Filter *.php | ForEach-Object {
+    (Get-Content $_.FullName -Raw) -replace "protected \`$signature = 'library:", "protected `$signature = 'resource-library:" | Set-Content $_.FullName -NoNewline
+}
+```
+
+- [ ] **Step 3: Verify no `library:` signatures remain**
+
+```bash
+grep "protected \$signature = 'library:" src/ || echo "clean"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Console
+git commit -m "chore: rename console command signatures from library:* to resource-library:*"
+```
+
+---
+
+## Task 6: Facade rename (if facade exists)
+
+**Files:**
+- Rename: `src/Facades/Library.php` → `src/Facades/ResourceLibrary.php` (if present)
+
+- [ ] **Step 1: Check whether a facade exists**
+
+```bash
+ls src/Facades 2>&1 || echo "no facades dir"
+```
+
+- [ ] **Step 2: If `src/Facades/Library.php` exists, rename + update class name**
+
+```bash
+if [ -f src/Facades/Library.php ]; then
+  git mv src/Facades/Library.php src/Facades/ResourceLibrary.php
+fi
+```
+
+Inside the renamed file (if it existed), update `class Library extends Facade` to `class ResourceLibrary extends Facade`.
+
+If no facade existed in v2, this task is a no-op.
+
+- [ ] **Step 3: Commit (skip if no-op)**
+
+```bash
+git add src/Facades 2>/dev/null
+if ! git diff --cached --quiet; then
+  git commit -m "chore: rename Library facade to ResourceLibrary"
+fi
+```
+
+---
+
+## Task 7: Tests namespace + assertion fixups
+
+**Files:**
+- Modify: every PHP file under `tests/` (namespace + table-name assertions)
+
+- [ ] **Step 1: Mass replace namespace in tests/**
+
+Bash:
+```bash
+find tests -name '*.php' -exec sed -i 's/Kurt\\\\Modules\\\\Library/Kurt\\\\Modules\\\\ResourceLibrary/g' {} +
+```
+
+PowerShell:
+```powershell
+Get-ChildItem -Path tests -Recurse -Filter *.php | ForEach-Object {
+    (Get-Content $_.FullName -Raw) -replace 'Kurt\\Modules\\Library', 'Kurt\Modules\ResourceLibrary' | Set-Content $_.FullName -NoNewline
+}
+```
+
+- [ ] **Step 2: Update `Database\Factories\Kurt\Modules\Library` namespace in factory references inside tests**
+
+Same sed/PowerShell pattern targeting `Database\\Modules\\Library` patterns.
+
+- [ ] **Step 3: Update test assertion strings that reference table names**
+
+```bash
+grep -rn "'library_" tests/ src/
+```
+Note any references to literal table names `library_folders`, `library_items`, etc. **Do NOT replace these yet** — Task 9 introduces the migration that renames the tables. Until then, tests continue running against the old table names.
+
+Specifically: tests SHOULD continue asserting on `library_*` table names through Task 8, and switch to `resource_library_*` table names in Task 9 once the rename migration lands.
+
+- [ ] **Step 4: Run tests to confirm namespace updates compile**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pest --no-coverage
+```
+
+Expected: tests run. Some may fail because the service provider's table prefix expectations don't match yet — that's fine for this task; Task 9 reconciles.
+
+If tests don't even load (PHP fatal), check namespace clean-up before continuing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests
+git commit -m "chore: rename namespace Kurt\Modules\Library to Kurt\Modules\ResourceLibrary in tests/"
+```
+
+---
+
+## Task 8: Factories namespace
+
+**Files:**
+- Modify: every PHP file under `database/factories/`
+
+- [ ] **Step 1: Replace factory namespace**
+
+Bash:
+```bash
+find database/factories -name '*.php' -exec sed -i 's/Database\\\\Factories\\\\Kurt\\\\Modules\\\\Library/Database\\\\Factories\\\\Kurt\\\\Modules\\\\ResourceLibrary/g' {} +
+find database/factories -name '*.php' -exec sed -i 's/Kurt\\\\Modules\\\\Library/Kurt\\\\Modules\\\\ResourceLibrary/g' {} +
+```
+
+PowerShell:
+```powershell
+Get-ChildItem -Path database/factories -Recurse -Filter *.php | ForEach-Object {
+    $content = Get-Content $_.FullName -Raw
+    $content = $content -replace 'Database\\Factories\\Kurt\\Modules\\Library', 'Database\Factories\Kurt\Modules\ResourceLibrary'
+    $content = $content -replace 'Kurt\\Modules\\Library', 'Kurt\Modules\ResourceLibrary'
+    Set-Content $_.FullName $content -NoNewline
+}
+```
+
+- [ ] **Step 2: Regenerate autoload**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe composer.phar dump-autoload
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add database/factories
+git commit -m "chore: rename namespace Database\Factories\Kurt\Modules\Library to Kurt\Modules\ResourceLibrary"
+```
+
+---
+
+## Task 9: Rename all `library_*` tables → `resource_library_*` via new migration
+
+**Files:**
+- Create: `database/migrations/2026_05_30_000100_rename_library_to_resource_library.php`
+
+- [ ] **Step 1: Write the rename migration**
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    /** @var array<int, array{0: string, 1: string}> */
+    private array $tables = [
+        ['library_access_log', 'resource_library_access_log'],
+        ['library_folder_permissions', 'resource_library_folder_permissions'],
+        ['library_item_tag', 'resource_library_item_tag'],
+        ['library_tags', 'resource_library_tags'],
+        ['library_item_versions', 'resource_library_item_versions'],
+        ['library_items', 'resource_library_items'],
+        ['library_folders', 'resource_library_folders'],
+    ];
+
+    public function up(): void
+    {
+        foreach ($this->tables as [$from, $to]) {
+            if (Schema::hasTable($from) && ! Schema::hasTable($to)) {
+                Schema::rename($from, $to);
+            }
+        }
+    }
+
+    public function down(): void
+    {
+        foreach (array_reverse($this->tables) as [$from, $to]) {
+            if (Schema::hasTable($to) && ! Schema::hasTable($from)) {
+                Schema::rename($to, $from);
+            }
+        }
+    }
+};
+```
+
+Order matters: rename leaf tables before parents to avoid FK constraint issues on some DB engines. The list above renames tables with FK dependencies (access_log, permissions, pivot, item_tag, versions) before their parents (items, folders).
+
+- [ ] **Step 2: Update existing migrations' `Schema::create` calls so a fresh install creates tables with the new names**
+
+For every file under `database/migrations/2026_05_28_030001_create_library_folders_table.php`-style:
+
+```bash
+find database/migrations -name "2026_05_28_*_create_library_*_table.php" -exec sed -i "s/Schema::create('library_/Schema::create('resource_library_/g" {} +
+find database/migrations -name "2026_05_28_*_create_library_*_table.php" -exec sed -i "s/Schema::dropIfExists('library_/Schema::dropIfExists('resource_library_/g" {} +
+find database/migrations -name "2026_05_28_*_create_library_*_table.php" -exec sed -i "s/constrained('library_/constrained('resource_library_/g" {} +
+```
+
+PowerShell equivalent:
+```powershell
+Get-ChildItem -Path database/migrations -Filter "2026_05_28_*_create_library_*_table.php" | ForEach-Object {
+    $content = Get-Content $_.FullName -Raw
+    $content = $content -replace "Schema::create\('library_", "Schema::create('resource_library_"
+    $content = $content -replace "Schema::dropIfExists\('library_", "Schema::dropIfExists('resource_library_"
+    $content = $content -replace "constrained\('library_", "constrained('resource_library_"
+    Set-Content $_.FullName $content -NoNewline
+}
+```
+
+Now a fresh install will create `resource_library_*` tables directly, while existing installs that already have `library_*` tables will get them renamed by the new migration.
+
+- [ ] **Step 3: Also rename the migration filenames themselves for cleanliness**
+
+```bash
+for f in database/migrations/2026_05_28_*_create_library_*_table.php; do
+  new="${f//create_library_/create_resource_library_}"
+  git mv "$f" "$new"
+done
+```
+
+PowerShell:
+```powershell
+Get-ChildItem -Path database/migrations -Filter "2026_05_28_*_create_library_*_table.php" | ForEach-Object {
+    $newName = $_.Name -replace 'create_library_', 'create_resource_library_'
+    git mv $_.FullName "database/migrations/$newName"
+}
+```
+
+- [ ] **Step 4: Update models' `$table` properties**
+
+Every model under `src/Models/` has a `protected $table = 'library_XYZ';`. Mass replace:
+
+```bash
+find src/Models -name '*.php' -exec sed -i "s/protected \\\$table = 'library_/protected \\\$table = 'resource_library_/g" {} +
+```
+
+PowerShell:
+```powershell
+Get-ChildItem -Path src/Models -Filter *.php | ForEach-Object {
+    (Get-Content $_.FullName -Raw) -replace "protected `\\\$table = 'library_", "protected `$table = 'resource_library_" | Set-Content $_.FullName -NoNewline
+}
+```
+
+- [ ] **Step 5: Update test assertions referencing old table names**
+
+```bash
+find tests -name '*.php' -exec sed -i "s/'library_/'resource_library_/g" {} +
+```
+
+Be careful — this also touches any non-table-name string starting with `library_`. Verify after:
+
+```bash
+grep -rn "'library_" tests/
+```
+
+If false positives (rare), restore those manually.
+
+- [ ] **Step 6: Update `hasMigrations(...)` list in the service provider**
+
+Open `src/Providers/ResourceLibraryServiceProvider.php`. Its `configurePackage()` calls `->hasMigrations([...])` with file names. Update each entry from `create_library_*_table` to `create_resource_library_*_table`.
+
+- [ ] **Step 7: Run full test suite**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pest
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 8: Run pint + phpstan**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pint --test
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/phpstan analyse --memory-limit=2G
+```
+
+Both must be clean.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add database/migrations src/Models src/Providers tests
+git commit -m "feat(resource-library): rename all library_* tables to resource_library_* via new migration + update existing create migrations + model \$table props"
+```
+
+---
+
+## Task 10: Docs — README + CHANGELOG + UPGRADE-3.0
+
+**Files:**
+- Modify: `README.md`
+- Modify: `CHANGELOG.md`
+- Create: `UPGRADE-3.0.md`
+
+- [ ] **Step 1: Rewrite README.md**
+
+Replace title heading from `# laravel-modules-library` to `# laravel-modules-resource-library`. Update the install command to `composer require ozankurt/laravel-modules-resource-library`. Update artisan command examples to `resource-library:*`. Note in a brief "v3.0 rename" section that this replaces the v2 `ozankurt/laravel-modules-library` package.
+
+- [ ] **Step 2: Prepend CHANGELOG.md entry**
+
+```markdown
+## [3.0.0] - 2026-05-30
+
+### Changed
+- **BREAKING:** Composer package renamed from `ozankurt/laravel-modules-library` to `ozankurt/laravel-modules-resource-library`.
+- **BREAKING:** PHP namespace renamed from `Kurt\Modules\Library\` to `Kurt\Modules\ResourceLibrary\`.
+- **BREAKING:** Config key renamed from `library` to `resource-library`. Update `config('library.foo')` → `config('resource-library.foo')`.
+- **BREAKING:** Service provider class renamed from `LibraryServiceProvider` to `ResourceLibraryServiceProvider`.
+- **BREAKING:** Artisan signatures renamed from `library:*` to `resource-library:*` (`library:recount` → `resource-library:recount`, etc.).
+- **BREAKING:** Database tables renamed from `library_*` to `resource_library_*` via a single auto-migration. Run `php artisan migrate` after upgrading.
+
+### Why
+
+The new `ozankurt/laravel-modules-media-library` package introduces a WordPress-style media bucket. To prevent confusion, the previous Library module — which is a SaaS *resource* library for sharing videos/files/documents with folder ACL — is renamed to ResourceLibrary.
+
+### Compatibility
+
+No functional behavior changes. All model methods, scopes, policy gates, and event class signatures remain identical. The repo URL on GitHub is unchanged.
+
+See [`UPGRADE-3.0.md`](./UPGRADE-3.0.md) for migration steps.
+```
+
+- [ ] **Step 3: Write UPGRADE-3.0.md**
+
+```markdown
+# Upgrade Guide — v2.x → v3.0
+
+The 3.0 release is a rename: composer name, namespace, config key, console signatures, and table prefix all change. No functional behavior changes.
+
+## 1. Composer
+
+```diff
+-"ozankurt/laravel-modules-library": "^2.0"
++"ozankurt/laravel-modules-resource-library": "^3.0"
+```
+
+Run `composer update`.
+
+## 2. PHP namespace
+
+Find-and-replace across your `app/` directory:
+
+| Find | Replace |
+|---|---|
+| `Kurt\Modules\Library\` | `Kurt\Modules\ResourceLibrary\` |
+| `Kurt\\Modules\\Library\\` | `Kurt\\Modules\\ResourceLibrary\\` |
+
+(VS Code regex: `\bKurt\\Modules\\Library\b` → `Kurt\Modules\ResourceLibrary`.)
+
+## 3. Config key
+
+```diff
+-config('library.media.disk')
++config('resource-library.media.disk')
+```
+
+If you've published the config file:
+
+```bash
+mv config/library.php config/resource-library.php
+```
+
+## 4. Artisan commands
+
+| Old | New |
+|---|---|
+| `library:recount` | `resource-library:recount` |
+| `library:prune-versions` | `resource-library:prune-versions` |
+| `library:rebuild-paths` | `resource-library:rebuild-paths` |
+| `library:demo` | `resource-library:demo` |
+
+Update any cron entries and scheduler bindings.
+
+## 5. Database tables
+
+Run pending migrations:
+
+```bash
+php artisan migrate
+```
+
+The `2026_05_30_000100_rename_library_to_resource_library` migration renames every `library_*` table to `resource_library_*`. Existing data is preserved.
+
+For new installations, fresh installs create the `resource_library_*` tables directly.
+
+## 6. Service provider
+
+If your app's `config/app.php` lists providers manually:
+
+```diff
+-Kurt\Modules\Library\Providers\LibraryServiceProvider::class,
++Kurt\Modules\ResourceLibrary\Providers\ResourceLibraryServiceProvider::class,
+```
+
+If you rely on Laravel's package auto-discovery, no change needed.
+
+## 7. Facades
+
+If you import the facade:
+
+```diff
+-use Kurt\Modules\Library\Facades\Library;
++use Kurt\Modules\ResourceLibrary\Facades\ResourceLibrary;
+
+-Library::createFolder(...);
++ResourceLibrary::createFolder(...);
+```
+
+## 8. Verify
+
+After upgrade:
+
+```bash
+php artisan migrate:status   # confirms the rename migration ran
+php artisan resource-library:demo   # smoke test
+```
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md CHANGELOG.md UPGRADE-3.0.md
+git commit -m "docs: rewrite README, prepend CHANGELOG entry, add UPGRADE-3.0 for v3 rename"
+```
+
+---
+
+## Task 11: Final verification
+
+- [ ] **Step 1: Run the full local CI suite**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pint --test
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/phpstan analyse --memory-limit=2G
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pest
+```
+
+All three must be green. The same test count as v2 (pre-rename) should still pass.
+
+- [ ] **Step 2: Verify the v3 migration is idempotent**
+
+```bash
+C:/laragon/bin/php/php-8.4.5-nts-Win32-vs17-x64/php.exe vendor/bin/pest tests/Feature/MigrationsTest.php
+```
+Expected: pass. If no such test exists, write a smoke test under `tests/Feature/RenameMigrationTest.php`:
+
+```php
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Schema;
+
+it('creates resource_library_* tables and not library_* tables on fresh install', function () {
+    foreach ([
+        'resource_library_folders', 'resource_library_items', 'resource_library_item_versions',
+        'resource_library_tags', 'resource_library_item_tag', 'resource_library_folder_permissions',
+        'resource_library_access_log',
+    ] as $table) {
+        expect(Schema::hasTable($table))->toBeTrue("missing {$table}");
+    }
+    foreach ([
+        'library_folders', 'library_items', 'library_item_versions',
+        'library_tags', 'library_item_tag', 'library_folder_permissions',
+        'library_access_log',
+    ] as $oldTable) {
+        expect(Schema::hasTable($oldTable))->toBeFalse("legacy table {$oldTable} should not exist on fresh install");
+    }
+});
+```
+
+Commit the smoke test:
+
+```bash
+git add tests/Feature/RenameMigrationTest.php
+git commit -m "test(resource-library): smoke test confirming fresh install uses resource_library_* tables"
+```
+
+---
+
+## Task 12: Push + PR + merge + tag
+
+- [ ] **Step 1: Push branch**
+
+```bash
+git push -u origin v3.0
+```
+
+- [ ] **Step 2: Open PR**
+
+```bash
+gh pr create --title "v3.0: rename ozankurt/laravel-modules-library to ozankurt/laravel-modules-resource-library" --body "$(cat <<'EOF'
+## Summary
+
+- Renames composer name, PHP namespace, service provider, config key, console signatures, and table prefix from `library*` to `resource_library*`.
+- No functional behavior changes.
+- New migration renames existing `library_*` tables to `resource_library_*` automatically.
+- Disambiguates from the upcoming `ozankurt/laravel-modules-media-library` (WordPress-style media bucket).
+
+See `UPGRADE-3.0.md` for the consumer migration steps.
+
+## Test plan
+- [x] vendor/bin/pint --test
+- [x] vendor/bin/phpstan analyse
+- [x] vendor/bin/pest (full suite — same count as v2)
+- [ ] CI matrix green on this PR
+EOF
+)"
+```
+
+- [ ] **Step 3: Wait for CI to go green**
+
+```bash
+gh pr checks <PR_NUMBER> --watch
+```
+
+- [ ] **Step 4: Merge**
+
+```bash
+gh pr merge <PR_NUMBER> --merge
+```
+
+- [ ] **Step 5: Tag v3.0.0 + release**
+
+```bash
+git switch master
+git pull
+git tag -a v3.0.0 -m "v3.0.0"
+git push origin v3.0.0
+gh release create v3.0.0 --title "v3.0.0" --notes-file CHANGELOG.md
+```
+
+---
+
+## Definition of done
+
+- [ ] composer.json + namespace + provider + config + commands + tables all renamed.
+- [ ] New `2026_05_30_000100_rename_library_to_resource_library` migration renames existing installs.
+- [ ] Existing create migrations updated so fresh installs use `resource_library_*` tables directly.
+- [ ] All v2 tests still pass.
+- [ ] Pint + PHPStan level 8 clean.
+- [ ] CI matrix green.
+- [ ] README + CHANGELOG + UPGRADE-3.0 in place.
+- [ ] Tagged `v3.0.0`; GitHub release published.
+- [ ] Downstream module's VCS-repo references continue working (URL unchanged on GitHub).

--- a/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
+++ b/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
@@ -225,6 +225,56 @@ events_session_check_ins              -- check-in once per (session × ticket)
   created_at, updated_at
   unique(session_id, ticket_id)
 
+events_price_tiers                     -- time-based pricing within a single ticket type
+  id, ticket_type_id (FK events_ticket_types, cascadeOnDelete),
+  name (string),                                              -- 'Early bird', 'Regular', 'Last minute'
+  starts_at, ends_at (timestamps nullable),                   -- both null = always active; first matching tier wins
+  price_minor (unsignedBigInteger),
+  capacity (unsignedInteger nullable),                        -- per-tier sub-quota; nullable inherits type
+  sold_count (unsignedBigInteger default 0),
+  position (unsignedInteger default 0),                       -- tie-break ordering when windows overlap
+  created_at, updated_at
+  index(ticket_type_id, starts_at, ends_at)
+
+events_ticket_add_ons                  -- catalog of optional extras per event (parking, dinner, merch)
+  id, event_id (FK events_events, cascadeOnDelete),
+  slug, name (json — translatable), description (json — translatable, nullable),
+  price_minor (unsignedBigInteger), currency (char(3)),
+  capacity (unsignedInteger nullable),                        -- nullable = unlimited
+  sold_count (unsignedBigInteger default 0),
+  scannable (boolean default false),                          -- if true, has its own QR token for door scanning
+  position (unsignedInteger default 0),
+  active (boolean default true),
+  created_at, updated_at, deleted_at
+  unique(event_id, slug)
+
+events_ticket_add_on_purchases         -- attaches an add-on to a ticket (one row per add-on per ticket)
+  id, ticket_id (FK events_tickets, cascadeOnDelete),
+  add_on_id (FK events_ticket_add_ons, restrictOnDelete),
+  order_item_id (FK events_order_items, cascadeOnDelete),     -- billing link
+  quantity (unsignedInteger default 1),
+  unit_price_minor (unsignedBigInteger),
+  line_total_minor (unsignedBigInteger),
+  status (string — enum: pending|paid|cancelled|refunded),
+  qr_token (string nullable, unique),                         -- only when scannable=true
+  checked_in_at (timestamp nullable),
+  checked_in_by (FK users nullable, nullOnDelete),
+  created_at, updated_at, deleted_at
+  index(ticket_id, status)
+
+events_referral_links                  -- organizer-created links for attribution + commission tracking
+  id, event_id (FK events_events nullable, nullOnDelete),     -- null = applies to any event of the organizer
+  organizer_id (FK users, cascadeOnDelete),                   -- who earns the attribution
+  code (string unique),
+  landing_path (string nullable),                             -- relative URL the link redirects to
+  commission_basis_points (unsignedInteger default 0),        -- e.g. 500 = 5.00% of order total
+  max_uses (unsignedInteger nullable),
+  uses_count (unsignedBigInteger default 0),
+  expires_at (timestamp nullable),
+  active (boolean default true),
+  created_at, updated_at, deleted_at
+  index(organizer_id, active)
+
 events_discount_codes
   id, code (string unique),
   description (string nullable),

--- a/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
+++ b/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
@@ -170,6 +170,7 @@ events_orders
   tax_rate_basis_points (unsignedInteger nullable),     -- e.g. 1900 = 19.00% VAT; nullable when tax not applicable
   currency (char(3)),
   discount_code_id (nullable, FK events_discount_codes, nullOnDelete),
+  referral_link_id (nullable, FK events_referral_links, nullOnDelete),  -- attribution
   processor (string nullable),                          -- e.g. 'stripe'
   processor_reference (string nullable),                -- gateway charge id
   paid_at (timestamp nullable),
@@ -183,6 +184,7 @@ events_orders
 events_order_items
   id, order_id (FK, cascadeOnDelete),
   ticket_type_id (FK events_ticket_types, restrictOnDelete),
+  price_tier_id (nullable, FK events_price_tiers, nullOnDelete),  -- which time-based tier applied at purchase
   quantity (unsignedInteger),
   unit_price_minor (unsignedBigInteger),
   line_total_minor (unsignedBigInteger),
@@ -272,6 +274,28 @@ events_applications
   created_at, updated_at
   unique(applicant_id, ticket_type_id)
   index(status, submitted_at)
+
+events_announcements                   -- organizer-broadcasts to attendees (Mail + Database notifications)
+  id, event_id (FK events_events, cascadeOnDelete),
+  author_id (FK users, restrictOnDelete),
+  subject (string), body (text),
+  audience (string — enum: all|registered|checked_in|by_ticket_type|by_session),
+  audience_filter (json nullable),                            -- e.g. {ticket_type_ids: [12, 17]} or {session_ids: [3]}
+  scheduled_for (timestamp nullable),                         -- null = send immediately; future = scheduled
+  sent_at (timestamp nullable),
+  recipient_count (unsignedInteger default 0),
+  created_at, updated_at, deleted_at
+  index(event_id, sent_at)
+
+events_announcement_recipients         -- per-recipient delivery audit
+  id, announcement_id (FK events_announcements, cascadeOnDelete),
+  attendee_id (FK events_attendees, cascadeOnDelete),
+  status (string — enum: pending|sent|failed|opened),
+  notification_id (string nullable),                          -- Laravel notifications.id reference if database channel used
+  sent_at, opened_at (timestamps nullable),
+  failure_reason (string nullable),
+  created_at, updated_at
+  unique(announcement_id, attendee_id)
 
 events_attendees                       -- a person attending; created when ticket issued
   id, event_id, ticket_id (FK events_tickets, cascadeOnDelete),
@@ -389,6 +413,11 @@ enum OrderStatus: string { case Pending='pending'; case Paid='paid'; case Cancel
 enum TicketStatus: string { case Issued='issued'; case Cancelled='cancelled'; case Refunded='refunded'; case CheckedIn='checked_in'; case Transferred='transferred'; }
 enum DiscountKind: string { case Percent='percent'; case FlatAmount='flat_amount'; }
 enum DiscountApplicationScope: string { case Order='order'; case PerTicket='per_ticket'; }
+enum AddOnPurchaseStatus: string { case Pending='pending'; case Paid='paid'; case Cancelled='cancelled'; case Refunded='refunded'; }
+
+namespace Kurt\Modules\Events\Attendance\Enums;
+enum AnnouncementAudience: string { case All='all'; case Registered='registered'; case CheckedIn='checked_in'; case ByTicketType='by_ticket_type'; case BySession='by_session'; }
+enum AnnouncementRecipientStatus: string { case Pending='pending'; case Sent='sent'; case Failed='failed'; case Opened='opened'; }
 enum DiscountScope: string { case Global='global'; case EventsSubset='events_subset'; }
 
 namespace Kurt\Modules\Events\Attendance\Enums;
@@ -629,9 +658,9 @@ Consumer apps operating outside the EU set the config to `0` to disable; consume
 
 Selection of dispatched events (all under `Kurt\Modules\Events\Events\`):
 
-- Catalog: `EventCreated`, `EventUpdated`, `EventPublished`, `EventCancelled`, `EventCompleted`, `OccurrenceGenerated`, `SessionCreated`, `SessionUpdated`, `SessionDeleted`.
-- Ticketing: `TicketTypeCreated`, `TicketTypeReleased`, `OrderCreated`, `OrderPaid`, `OrderCancelled`, `OrderRefunded`, `OrderPartiallyRefunded`, `TicketIssued`, `TicketTransferRequested`, `TicketTransferred`, `TicketCheckedIn`, `SessionCheckedIn`, `DiscountCodeApplied`.
-- Attendance: `ApplicationSubmitted`, `ApplicationApproved`, `ApplicationRejected`, `AttendeeRegistered`, `AttendeeCancelled`, `AttendanceFormResponseStored`.
+- Catalog: `EventCreated`, `EventUpdated`, `EventPublished`, `EventCancelled`, `EventCompleted`, `EventApprovedForPublication`, `OccurrenceGenerated`, `SessionCreated`, `SessionUpdated`, `SessionDeleted`.
+- Ticketing: `TicketTypeCreated`, `TicketTypeReleased`, `PriceTierCreated`, `PriceTierActivated`, `OrderCreated`, `OrderPaid`, `OrderCancelled`, `OrderRefunded`, `OrderPartiallyRefunded`, `TicketIssued`, `TicketTransferRequested`, `TicketTransferred`, `TicketCheckedIn`, `SessionCheckedIn`, `DiscountCodeApplied`, `AddOnPurchased`, `AddOnRefunded`, `AddOnCheckedIn`, `ReferralAttributionRecorded`.
+- Attendance: `ApplicationSubmitted`, `ApplicationApproved`, `ApplicationRejected`, `AttendeeRegistered`, `AttendeeCancelled`, `AttendanceFormResponseStored`, `AnnouncementScheduled`, `AnnouncementSent`.
 - Eligibility: `DocumentUploaded`, `DocumentVerified`, `DocumentRejected`, `RequirementCheckPassed`, `RequirementCheckFailed`.
 - Flow: `QueueJoined`, `QueueReleased` (broadcast), `QueueExpired`, `WaitlistJoined`, `WaitlistPromoted` (broadcast), `WaitlistExpired`, `RefundRequested`, `RefundProcessed`, `RefundFailed`.
 
@@ -680,6 +709,19 @@ final class Events
     public function queueHeartbeat(SaleQueueEntry $entry): void;
     public function joinWaitlist(TicketType $type, Model $user, int $quantity = 1): WaitlistEntry;
     public function claimWaitlist(WaitlistEntry $entry): Order;
+
+    /** @param array<int, array{add_on_id: int, quantity: int}> $addOnSelections */
+    public function purchaseAddOns(Ticket $ticket, array $addOnSelections): Order;
+    public function checkInAddOn(string $qrToken, Model $scanner): TicketAddOnPurchase;
+
+    public function announce(
+        Event $event, Model $author, string $subject, string $body,
+        AnnouncementAudience $audience = AnnouncementAudience::All,
+        array $audienceFilter = [],
+        ?\DateTimeInterface $scheduledFor = null,
+    ): Announcement;
+
+    public function attributeReferral(Order $order, string $code): void;  // called by consumer at checkout when referral cookie present
 }
 ```
 
@@ -901,7 +943,8 @@ return [
 - `events:generate-occurrences` — daily. Materialises recurring events into the rolling window.
 - `events:dispatch-reminders` — every 5 minutes. Sends reminders for events crossing each `before_hours` threshold (per-event override read from `events.reminder_intervals`).
 - `events:expire-pending-orders` — every minute. Cancels orders stuck in `pending` past `events.orders.pending_timeout_minutes` and releases held capacity.
-- `events:demo` — seeds a sample event, ticket types, discount code, attendees.
+- `events:dispatch-announcements` — every minute. Sends scheduled announcements whose `scheduled_for` has arrived.
+- `events:demo` — seeds a sample event, ticket types, price tiers, add-ons, referral link, discount code, attendees.
 
 ## 21. Optional Laravel Notifications
 

--- a/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
+++ b/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
@@ -430,6 +430,31 @@ events_waitlist_entries                -- after ticket_type sells out
   unique(ticket_type_id, user_id)
   index(ticket_type_id, status, created_at)
 
+events_event_templates                 -- reusable starting points for new events
+  id, owner_id (FK users, cascadeOnDelete),
+  slug, name (string), description (text nullable),
+  payload (json),                                            -- snapshot of event + ticket types + sessions + requirements + add-ons + price tiers
+  is_public (boolean default false),                         -- when true, other organizers can use it
+  used_count (unsignedBigInteger default 0),
+  created_at, updated_at, deleted_at
+  unique(owner_id, slug)
+  index(is_public)
+
+events_audit_log                       -- our own audit log (independent of spatie/activitylog)
+  id, event_id (FK events_events nullable, nullOnDelete),    -- nullable for org-wide events (e.g., template usage)
+  actor_id (FK users nullable, nullOnDelete),                -- null for system actions
+  actor_type (string nullable),                              -- 'system', 'organizer', 'attendee', 'platform_admin'
+  action (string),                                           -- domain action key: 'event.published', 'ticket.transferred', 'refund.processed', …
+  subject_type (string nullable),                            -- FQCN of subject model
+  subject_id (unsignedBigInteger nullable),
+  changes (json nullable),                                   -- {before: {...}, after: {...}} attribute diff
+  context (json nullable),                                   -- request metadata: ip, user_agent, route
+  occurred_at (timestamp, indexed),
+  created_at, updated_at
+  index(event_id, occurred_at)
+  index(action)
+  index(subject_type, subject_id)
+
 events_refunds
   id, order_id (FK events_orders, cascadeOnDelete),
   ticket_id (nullable, FK events_tickets, nullOnDelete),     -- present for partial per-ticket refunds
@@ -704,6 +729,40 @@ Module behaviour:
 
 Consumer apps operating outside the EU set the config to `0` to disable; consumer apps inside the EU keep the default. The module itself doesn't infer jurisdiction.
 
+## 13a. Pluggable contracts
+
+Module defines a small set of optional contracts. Each is bound by FQCN in `config/events.php`; module instantiates via the container when present.
+
+```php
+namespace Kurt\Modules\Events\Eligibility\Contracts;
+interface DocumentVerifier { /* §16.x */ }
+interface RequirementEvaluator { /* §7.1 */ }
+interface GroupResolver
+{
+    /** @return array<int, string> Group identifiers the user belongs to. */
+    public function groupsFor(\Illuminate\Database\Eloquent\Model $user): array;
+}
+
+namespace Kurt\Modules\Events\Flow\Contracts;
+interface QueueChallengeProvider
+{
+    /** Throws QueueChallengeFailed when the supplied token is invalid. */
+    public function verify(\Illuminate\Database\Eloquent\Model $user, string $challengeToken, array $context = []): void;
+}
+
+namespace Kurt\Modules\Events\Catalog\Contracts;
+interface EventChatBridge
+{
+    /** Returns an opaque room identifier the consumer's chat tool can resolve, or null. */
+    public function roomIdFor(Event $event): ?string;
+
+    /** Called by Events::publish() once a room exists; consumer may store the id on Event::data. */
+    public function ensureRoomFor(Event $event): ?string;
+}
+```
+
+The chat bridge is the canonical way to integrate any chat backend (including KurtModules-Chat) without creating a cross-module hard dependency. Spec §3 of the umbrella forbids those, so this stays a contract.
+
 ## 14. Domain events
 
 Selection of dispatched events (all under `Kurt\Modules\Events\Events\`):
@@ -711,6 +770,8 @@ Selection of dispatched events (all under `Kurt\Modules\Events\Events\`):
 - Catalog: `EventCreated`, `EventUpdated`, `EventPublished`, `EventCancelled`, `EventCompleted`, `EventApprovedForPublication`, `OccurrenceGenerated`, `SessionCreated`, `SessionUpdated`, `SessionDeleted`.
 - Ticketing: `TicketTypeCreated`, `TicketTypeReleased`, `PriceTierCreated`, `PriceTierActivated`, `OrderCreated`, `OrderPaid`, `OrderCancelled`, `OrderRefunded`, `OrderPartiallyRefunded`, `TicketIssued`, `TicketTransferRequested`, `TicketTransferred`, `TicketCheckedIn`, `SessionCheckedIn`, `DiscountCodeApplied`, `AddOnPurchased`, `AddOnRefunded`, `AddOnCheckedIn`, `ReferralAttributionRecorded`.
 - Attendance: `ApplicationSubmitted`, `ApplicationApproved`, `ApplicationRejected`, `AttendeeRegistered`, `AttendeeCancelled`, `AttendanceFormResponseStored`, `AnnouncementScheduled`, `AnnouncementSent`.
+- Catalog (continued): `EventClonedFrom`, `EventTemplateSaved`, `EventCreatedFromTemplate`.
+- Audit: `AuditLogEntryRecorded` (low-level, dispatched by the audit writer itself; useful for opt-in shipping to external SIEMs).
 - Eligibility: `DocumentUploaded`, `DocumentVerified`, `DocumentRejected`, `RequirementCheckPassed`, `RequirementCheckFailed`.
 - Flow: `QueueJoined`, `QueueReleased` (broadcast), `QueueExpired`, `WaitlistJoined`, `WaitlistPromoted` (broadcast), `WaitlistExpired`, `RefundRequested`, `RefundProcessed`, `RefundFailed`.
 
@@ -772,6 +833,14 @@ final class Events
     ): Announcement;
 
     public function attributeReferral(Order $order, string $code): void;  // called by consumer at checkout when referral cookie present
+
+    /**
+     * @param array<string, mixed> $overrides Field overrides applied to the cloned event (title, slug, starts_at, etc.).
+     */
+    public function cloneEvent(Event $source, array $overrides = []): Event;
+
+    public function saveAsTemplate(Event $source, Model $owner, string $name, ?string $slug = null, bool $public = false): EventTemplate;
+    public function createEventFromTemplate(EventTemplate $template, Model $organizer, array $overrides = []): Event;
 }
 ```
 
@@ -858,7 +927,25 @@ When the config flag is `false` (default), the flow stays exactly as before — 
 
 The `canManageEventApprovals` gate guards `approveForPublication`. Consumers register their staff/admin roles against that gate.
 
-### 16.7 Search & discovery scopes
+### 16.7 Audit log
+
+Every state-changing facade method writes one or more rows to `events_audit_log`. The module does not depend on `spatie/laravel-activitylog`; this log is internal and queryable directly.
+
+Action keys follow the `{aggregate}.{verb}` pattern: `event.created`, `event.published`, `event.cancelled`, `ticket.issued`, `ticket.transferred`, `order.paid`, `order.refunded`, `refund.processed`, `application.approved`, `requirement.checked`, `announcement.sent`, `referral.attributed`, etc.
+
+`changes` carries a `{before, after}` JSON diff for update actions. `context` is populated by a request-scoped middleware-like callback the consumer registers in the service provider; default captures `ip` and `user_agent` from the active request when available.
+
+`Events::auditLogFor(Event|Order|Ticket|Refund $subject, ?int $limit = 100)` returns the audit trail for any first-class subject, sorted descending by `occurred_at`.
+
+### 16.8 Event templates & cloning
+
+Two related helpers:
+
+- **`Events::cloneEvent($source, $overrides)`** — copies the event + its ticket types, sessions, attendance forms, requirements, add-ons, price tiers (but never sales data: orders, tickets, applications, attendees, refunds). Returns a new event in `Draft` (or `PendingApproval` when configured). Overrides are field-level (e.g., `['title' => 'Concert 2027', 'starts_at' => …]`). Useful for ad-hoc duplication of a one-off event.
+
+- **`EventTemplate` model + `saveAsTemplate()` / `createEventFromTemplate()`** — explicit reusable templates. Saving captures the same payload as cloneEvent into `events_event_templates.payload`. Templates can be private to the owner or `is_public=true` so other organizers can spawn events from them. Each spawn increments `used_count`.
+
+### 16.9 Search & discovery scopes
 
 `Event::class` exposes the following query scopes for consumers building list endpoints:
 
@@ -929,6 +1016,19 @@ return [
 
     'publishing' => [
         'require_approval' => false,              // when true, new events start in EventStatus::PendingApproval and need admin approval
+    ],
+
+    'audit' => [
+        'enabled' => true,
+        'capture_context' => true,                // when true, populate audit_log.context.ip + .user_agent from the active request
+    ],
+
+    'anti_bot' => [
+        'queue_challenge' => null,                // FQCN implementing QueueChallengeProvider; null = no challenge
+    ],
+
+    'chat_bridge' => [
+        'provider' => null,                       // FQCN implementing EventChatBridge; null = no bridge
     ],
 
     'documents' => [

--- a/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
+++ b/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
@@ -103,6 +103,7 @@ events_events
   online_url (string nullable),
   cover_path (string nullable),  -- denormalised from medialibrary
   reminder_intervals (json nullable),  -- nullable = use events.reminders.before_hours global default
+  attendee_list_visibility (string — enum: private|organizer_only|attendees_only|public, default 'organizer_only'),
 
   -- Recurrence (single events leave both null)
   parent_event_id (nullable, self FK, cascadeOnDelete),  -- for occurrences of a recurring series
@@ -374,8 +375,9 @@ events_refunds
 
 ```php
 namespace Kurt\Modules\Events\Catalog\Enums;
-enum EventStatus: string { case Draft='draft'; case Published='published'; case Cancelled='cancelled'; case Completed='completed'; }
+enum EventStatus: string { case Draft='draft'; case PendingApproval='pending_approval'; case Published='published'; case Cancelled='cancelled'; case Completed='completed'; }
 enum EventVisibility: string { case Public='public'; case Unlisted='unlisted'; case Private='private'; }
+enum AttendeeListVisibility: string { case Private='private'; case OrganizerOnly='organizer_only'; case AttendeesOnly='attendees_only'; case Public='public'; }
 enum LocationKind: string { case Physical='physical'; case Online='online'; case Hybrid='hybrid'; }
 enum RecurrenceFrequency: string { case None='none'; case Daily='daily'; case Weekly='weekly'; case Monthly='monthly'; case Yearly='yearly'; }
 enum OrganizerRole: string { case Owner='owner'; case Manager='manager'; case Scanner='scanner'; }
@@ -647,6 +649,7 @@ use Kurt\Modules\Events\Flow\Models\{SaleQueueEntry, WaitlistEntry, Refund};
 final class Events
 {
     public function createEvent(array $data, Model $organizer): Event;
+    public function approveForPublication(Event $event, Model $platformAdmin): void;  // only when events.publishing.require_approval=true
     public function publish(Event $event): void;
     public function cancel(Event $event, Model $canceller, string $reason): void;
 
@@ -739,7 +742,31 @@ Read-heavy paths (search scopes, listing endpoints) do not lock — they tolerat
 5. If neither allowance applies, throws `SelfCancellationNotPermitted` (typed exception). Buyer can still ask the organizer.
 6. Otherwise creates a `Refund` with `reason=attendee_request`, dispatches `RefundRequested`, and returns the Refund row.
 
-### 16.5 Search & discovery scopes
+### 16.5 Attendee list privacy
+
+`Event::attendee_list_visibility` declares the most permissive level. The effective visibility for any given attendee is the more restrictive of:
+
+- the event's `attendee_list_visibility`, and
+- the attendee's own `profile.list_visibility` (null treated as `public`, valid values are `public` or `private`).
+
+`Event::visibleAttendees(?Model $viewer): Collection`:
+
+- `private` — empty collection regardless of viewer.
+- `organizer_only` — returns attendees only when `$viewer` is an organizer (any role).
+- `attendees_only` — returns attendees only when `$viewer` is also an attendee on the same event.
+- `public` — returns attendees with `profile.list_visibility !== 'private'`.
+
+This protects organizer-level lookups (always full list) from public-facing rendering. Default is `organizer_only` so an unconfigured event never leaks attendee data.
+
+### 16.6 Event approval workflow
+
+When `events.publishing.require_approval` is `true`, `Events::createEvent(...)` writes the event with `status = EventStatus::PendingApproval` rather than `Draft`. The organizer cannot transition the event toward `Published` until `Events::approveForPublication($event, $platformAdmin)` runs; that call dispatches `EventApprovedForPublication` and moves the event to `Draft`. The organizer then proceeds with normal `publish()`.
+
+When the config flag is `false` (default), the flow stays exactly as before — new events land in `Draft` and can be published directly by the organizer.
+
+The `canManageEventApprovals` gate guards `approveForPublication`. Consumers register their staff/admin roles against that gate.
+
+### 16.7 Search & discovery scopes
 
 `Event::class` exposes the following query scopes for consumers building list endpoints:
 
@@ -806,6 +833,10 @@ return [
 
     'tax' => [
         'enabled' => true,                        // when false, tax_minor + tax_rate_basis_points stay null
+    ],
+
+    'publishing' => [
+        'require_approval' => false,              // when true, new events start in EventStatus::PendingApproval and need admin approval
     ],
 
     'documents' => [

--- a/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
+++ b/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
@@ -97,10 +97,8 @@ events_events
   status (string — enum), visibility (string — enum),
   starts_at (timestamp), ends_at (timestamp),
   timezone (string default 'UTC'),
-  location_kind (string — enum: physical|online|hybrid),
   location_name (string nullable), location_address (text nullable),
   latitude (decimal(10,7) nullable), longitude (decimal(10,7) nullable),  -- for nearLocation() scope
-  online_url (string nullable),
   cover_path (string nullable),  -- denormalised from medialibrary
   reminder_intervals (json nullable),  -- nullable = use events.reminders.before_hours global default
   attendee_list_visibility (string — enum: private|organizer_only|attendees_only|public, default 'organizer_only'),
@@ -127,8 +125,10 @@ events_events
 events_event_tag                     -- pivot
   event_id, tag_id, primary(event_id, tag_id)
 
-events_event_organizers              -- pivot with role
-  id, event_id, user_id, role (string — enum), created_at, updated_at
+events_event_organizers              -- pivot with role + revenue split
+  id, event_id, user_id, role (string — enum),
+  commission_basis_points (unsignedInteger nullable),         -- nullable = no share; 10000 = 100%; sum across organizers should equal 10000 when revenue is split
+  created_at, updated_at
   unique(event_id, user_id)
 ```
 
@@ -261,6 +261,49 @@ events_ticket_add_on_purchases         -- attaches an add-on to a ticket (one ro
   checked_in_by (FK users nullable, nullOnDelete),
   created_at, updated_at, deleted_at
   index(ticket_id, status)
+
+events_sponsor_tiers                   -- sponsor levels per event (Gold/Silver/Bronze)
+  id, event_id (FK events_events, cascadeOnDelete),
+  slug, name (string),                                        -- displayed label
+  price_minor (unsignedBigInteger), currency (char(3)),
+  comp_ticket_quota (unsignedInteger default 0),              -- complimentary tickets auto-issued per sponsor at this tier
+  comp_ticket_type_id (nullable, FK events_ticket_types, nullOnDelete),  -- which type to issue (null = sponsor picks)
+  benefits (json nullable),                                   -- structured perks list rendered in admin
+  position (unsignedInteger default 0),
+  created_at, updated_at, deleted_at
+  unique(event_id, slug)
+
+events_sponsors                        -- a sponsor's purchase of a tier for an event
+  id, event_id (FK events_events, cascadeOnDelete),
+  sponsor_tier_id (FK events_sponsor_tiers, restrictOnDelete),
+  name (string),                                              -- company name displayed
+  contact_user_id (FK users nullable, nullOnDelete),          -- primary contact who manages comp tickets
+  logo_path (string nullable),                                -- via medialibrary
+  website_url (string nullable),
+  blurb (text nullable),
+  status (string — enum: pending|active|cancelled),
+  order_id (FK events_orders nullable, nullOnDelete),         -- B2B billing order for the sponsorship itself
+  position (unsignedInteger default 0),
+  created_at, updated_at, deleted_at
+  index(event_id, status)
+
+events_sponsor_comp_tickets            -- audit of which tickets were issued from sponsorship quotas
+  id, sponsor_id (FK events_sponsors, cascadeOnDelete),
+  ticket_id (FK events_tickets, cascadeOnDelete),
+  issued_at (timestamp),
+  created_at, updated_at
+  unique(sponsor_id, ticket_id)
+
+events_payout_ledger                   -- per-organizer share of paid orders
+  id, order_id (FK events_orders, cascadeOnDelete),
+  organizer_user_id (FK users, restrictOnDelete),
+  share_basis_points (unsignedInteger),                       -- snapshot of commission at the time
+  amount_minor (unsignedBigInteger), currency (char(3)),
+  status (string — enum: accrued|paid_out|reversed),
+  paid_out_at (timestamp nullable),
+  payout_reference (string nullable),                         -- consumer-supplied reference when status flips to paid_out
+  created_at, updated_at
+  index(organizer_user_id, status)
 
 events_referral_links                  -- organizer-created links for attribution + commission tracking
   id, event_id (FK events_events nullable, nullOnDelete),     -- null = applies to any event of the organizer
@@ -477,10 +520,13 @@ namespace Kurt\Modules\Events\Catalog\Enums;
 enum EventStatus: string { case Draft='draft'; case PendingApproval='pending_approval'; case Published='published'; case Cancelled='cancelled'; case Completed='completed'; }
 enum EventVisibility: string { case Public='public'; case Unlisted='unlisted'; case Private='private'; }
 enum AttendeeListVisibility: string { case Private='private'; case OrganizerOnly='organizer_only'; case AttendeesOnly='attendees_only'; case Public='public'; }
-enum LocationKind: string { case Physical='physical'; case Online='online'; case Hybrid='hybrid'; }
+// LocationKind enum dropped — module supports physical events only.
 enum RecurrenceFrequency: string { case None='none'; case Daily='daily'; case Weekly='weekly'; case Monthly='monthly'; case Yearly='yearly'; }
 enum OrganizerRole: string { case Owner='owner'; case Manager='manager'; case Scanner='scanner'; }
 // Sessions reuse AttendeeStatus for check-in tracking; no dedicated enum needed.
+
+enum SponsorStatus: string { case Pending='pending'; case Active='active'; case Cancelled='cancelled'; }
+enum PayoutStatus: string { case Accrued='accrued'; case PaidOut='paid_out'; case Reversed='reversed'; }
 
 namespace Kurt\Modules\Events\Ticketing\Enums;
 enum TicketTypeMode: string { case Open='open'; case Application='application'; case Rsvp='rsvp'; }
@@ -841,6 +887,21 @@ final class Events
 
     public function saveAsTemplate(Event $source, Model $owner, string $name, ?string $slug = null, bool $public = false): EventTemplate;
     public function createEventFromTemplate(EventTemplate $template, Model $organizer, array $overrides = []): Event;
+
+    // Sponsors
+    public function addSponsorTier(Event $event, array $data): SponsorTier;
+    public function purchaseSponsorship(Event $event, SponsorTier $tier, Model $contactUser, array $data): Sponsor;
+    public function issueCompTicket(Sponsor $sponsor, Model $holder, array $assignmentData): Ticket;
+
+    // GDPR
+    /** @return array<string, mixed> Structured personal-data dump suitable for JSON/CSV export. */
+    public function exportPersonalData(Model $user): array;
+    /** Replaces PII on the user's rows with hashed/null values; preserves aggregates + audit log shape. */
+    public function anonymizePersonalData(Model $user): void;
+
+    // Payouts (lightweight ledger)
+    public function recordPayout(int $ledgerEntryId, string $reference): void;       // flips status to paid_out
+    public function reversePayout(int $ledgerEntryId, string $reason): void;          // flips status to reversed
 }
 ```
 
@@ -1031,6 +1092,15 @@ return [
         'provider' => null,                       // FQCN implementing EventChatBridge; null = no bridge
     ],
 
+    'gdpr' => [
+        'retention_days' => null,                 // null = no automatic retention; e.g. 730 = anonymize records older than 2 years
+        'anonymize_audit_log_actor' => true,      // when anonymizing a user, also null their actor_id on existing audit_log rows
+    ],
+
+    'payouts' => [
+        'auto_accrue_on_order_paid' => true,      // when true, events_payout_ledger rows are written automatically per organizer share
+    ],
+
     'documents' => [
         'disk' => env('EVENTS_DOCUMENT_DISK', 'private'),
         'verifier' => null,                // FQCN implementing DocumentVerifier; null = manual review
@@ -1094,7 +1164,8 @@ return [
 - `events:dispatch-reminders` — every 5 minutes. Sends reminders for events crossing each `before_hours` threshold (per-event override read from `events.reminder_intervals`).
 - `events:expire-pending-orders` — every minute. Cancels orders stuck in `pending` past `events.orders.pending_timeout_minutes` and releases held capacity.
 - `events:dispatch-announcements` — every minute. Sends scheduled announcements whose `scheduled_for` has arrived.
-- `events:demo` — seeds a sample event, ticket types, price tiers, add-ons, referral link, discount code, attendees.
+- `events:enforce-retention` — daily. Anonymizes records older than `events.gdpr.retention_days` for users with no recent activity. Null retention disables.
+- `events:demo` — seeds a sample event, ticket types, price tiers, add-ons, referral link, discount code, sponsor, attendees.
 
 ## 21. Optional Laravel Notifications
 
@@ -1188,6 +1259,36 @@ Implementation plan will reference this spec and structure work into ~15 tasks.
 - [ ] ICS exporter validated against a real calendar (manual verification once).
 - [ ] README + CHANGELOG + LICENSE in place.
 - [ ] Tagged `v1.0.0` after merge to master.
+
+## 25.5 GDPR / data-protection helpers
+
+### Personal-data export
+
+`Events::exportPersonalData(Model $user)` returns a structured `array<string, mixed>` containing every row associated with the user across `events_attendees`, `events_applications`, `events_orders`, `events_order_item_assignments`, `events_tickets`, `events_refunds`, `events_document_uploads`, `events_audit_log`, `events_announcement_recipients`, `events_sale_queue_entries`, `events_waitlist_entries`. The consumer serialises to JSON or CSV as needed for the data-subject access request response.
+
+### Anonymisation
+
+`Events::anonymizePersonalData(Model $user)` walks the same set of tables and:
+
+- replaces `holder_name`, `holder_email`, `decision_note`, `note`, `failure_reason` and similar PII text columns with a hash of the original value (or `null` when nullable);
+- replaces `profile`, `metadata`, `answers`, `holder_metadata`, `decision_metadata` JSON columns with `{anonymized_at: ISO8601}`;
+- when `events.gdpr.anonymize_audit_log_actor=true`, sets `events_audit_log.actor_id = null` for past rows acted on by this user, preserving the action keys for system trail;
+- aggregates (counts, sold_count, etc.) are preserved;
+- does NOT delete refund rows (financial records typically have a separate legal retention window managed by the consumer's accounting system).
+
+### Retention command
+
+`events:enforce-retention` runs daily when scheduled. For each user with `last activity > events.gdpr.retention_days` (no order/application/ticket touched), it calls `anonymizePersonalData` automatically. The window is configurable; null disables the command.
+
+### DPIA + data-flow documentation
+
+The repo ships `docs/gdpr/` with:
+
+- `data-flow.md` — diagram of personal data flow through the module's tables.
+- `processing-record.md` — Article 30 record-of-processing template that consumers can adapt.
+- `dsr-checklist.md` — operational checklist for handling data-subject requests.
+
+These are documentation only and ship as part of the package's distribution (not export-ignored).
 
 ## 26. Open follow-ups (not in v1.0)
 

--- a/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
+++ b/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
@@ -1,0 +1,733 @@
+# `ozankurt/laravel-modules-events` v1.0 — Spec
+
+**Repo:** `KurtModules-Events` (to be created)
+**Date:** 2026-05-29
+**Status:** Draft → user review pending
+**Family:** [KurtModules v2 umbrella](./2026-05-28-kurtmodules-v2-design.md)
+
+---
+
+## 1. Purpose
+
+A **flexible event management** module for Laravel SaaS apps. Covers create/publish/cancel events, sell or RSVP tickets, applications with organizer approval, document/age/group-membership requirements, capacity + waitlist + queue (waiting-room) for hot sales, discount codes, refund tracking, recurring events with ICS export, and a Filament admin (planned v1.1).
+
+The module is **payment-agnostic** — it tracks Order/Ticket/Refund states and emits domain events. Consumers wire their payment gateway (Stripe/Paddle/manual) by responding to those events.
+
+The module is **transport-agnostic for real-time** — the sale queue + waitlist promotion work over polling (HTTP) or broadcasting (Reverb/Pusher). It ships both: a heartbeat endpoint pattern + broadcast events (`QueueReleased`, `WaitlistPromoted`).
+
+This is a **greenfield module**, initial release `v1.0.0` (not v2 — the family-wide v2 line is the renovation of the existing five; Events is new and starts at 1.0).
+
+## 2. Modules-in-family relationship
+
+Sibling to Blog/Chat/Forum/Library/Core. Same conventions per the [umbrella v2 design](./2026-05-28-kurtmodules-v2-design.md). Depends on Core only. No coupling to Blog/Chat/Forum/Library.
+
+## 3. Stack & metadata
+
+| | |
+|---|---|
+| Composer name | `ozankurt/laravel-modules-events` |
+| PHP namespace | `Kurt\Modules\Events\` |
+| Table prefix | `events_` |
+| PHP | `^8.4` |
+| Laravel | `^12.0 \|\| ^13.0` |
+| Core | `ozankurt/laravel-modules-core: ^2.0` |
+| Media | `spatie/laravel-medialibrary: ^11.0` (documents, event covers) |
+| Translatable | `spatie/laravel-translatable: ^6.11` (event title/description/ticket-type name etc.) |
+| Sluggable | `cviebrock/eloquent-sluggable: ^11.0 \|\| ^12.0` |
+| Filament | `^3.0 \|\| ^4.0 \|\| ^5.0` (require-dev; resources land v1.1) |
+| Tests | Pest 3 + Testbench + PHPStan 8 + Pint, GH Actions CI |
+
+## 4. Architecture: 5 sub-aggregates
+
+Code is organised by sub-aggregate, not by technical layer. Each sub-aggregate has its own `Models/`, `Enums/`, `Support/` (where needed).
+
+```
+src/
+  Catalog/                # The event itself + recurrence + organizers + taxonomy
+  Ticketing/              # Ticket types, orders, tickets, discount codes
+  Attendance/             # Attendees, applications, custom forms
+  Eligibility/            # Requirements engine + document verification
+  Flow/                   # Queue + waitlist + refunds + reminders
+
+  Concerns/               # IsEventOrganizer, IsEventAttendee user traits
+  Contracts/              # EventOrganizer, EventAttendee, DocumentVerifier, RequirementEvaluator
+  Events/                 # Domain events (Laravel events)
+  Notifications/          # Optional Laravel Notification classes (Mail+Database)
+  Policies/
+  Providers/EventsServiceProvider.php
+  Support/Events.php      # Top-level facade-style entry point
+```
+
+## 5. Data model
+
+All tables use `bigIncrements`, `softDeletes()`, `timestamps()`. Money columns are `unsignedBigInteger` storing **minor units** (cents) — `100` = `1.00 USD`. Currency is a 3-char ISO 4217 code stored as `string`. JSON for translatable text + flexible payloads.
+
+### 5.1 Catalog
+
+```
+events_categories                    -- optional grouping
+  id, slug, name (json — translatable), description (json — translatable, nullable),
+  parent_id (nullable, self FK, restrictOnDelete), position (unsigned int),
+  created_at, updated_at, deleted_at
+
+events_tags
+  id, slug, name (json — translatable),
+  created_at, updated_at
+
+events_events
+  id, slug, title (json — translatable), description (json — translatable, nullable),
+  category_id (nullable, FK events_categories, nullOnDelete),
+  status (string — enum), visibility (string — enum),
+  starts_at (timestamp), ends_at (timestamp),
+  timezone (string default 'UTC'),
+  location_kind (string — enum: physical|online|hybrid),
+  location_name (string nullable), location_address (text nullable),
+  online_url (string nullable),
+  cover_path (string nullable),  -- denormalised from medialibrary
+
+  -- Recurrence (single events leave both null)
+  parent_event_id (nullable, self FK, cascadeOnDelete),  -- for occurrences of a recurring series
+  recurrence_rule (json nullable),                       -- {frequency, interval, count, until, byDay, byMonthDay}
+
+  -- Capacity
+  capacity (unsignedInteger nullable),                   -- nullable = unlimited at event level
+  sale_starts_at (timestamp nullable), sale_ends_at (timestamp nullable),
+  cancelled_at (timestamp nullable), cancelled_by (FK users, nullable, nullOnDelete),
+  cancellation_reason (text nullable),
+
+  -- Counters (denormalised)
+  tickets_sold_count (unsignedBigInteger default 0),
+  attendees_count (unsignedBigInteger default 0),
+  applications_pending_count (unsignedInteger default 0),
+
+  created_at, updated_at, deleted_at
+  index(status, starts_at)
+  index(parent_event_id)
+
+events_event_tag                     -- pivot
+  event_id, tag_id, primary(event_id, tag_id)
+
+events_event_organizers              -- pivot with role
+  id, event_id, user_id, role (string — enum), created_at, updated_at
+  unique(event_id, user_id)
+```
+
+### 5.2 Ticketing
+
+```
+events_ticket_types
+  id, event_id (FK events_events, cascadeOnDelete),
+  slug, name (json — translatable), description (json — translatable, nullable),
+  mode (string — enum: open|application|rsvp),
+  price_minor (unsignedBigInteger default 0), currency (string char(3) default 'USD'),
+  refundable (boolean default true),
+  capacity (unsignedInteger nullable),                  -- per-type capacity
+  sold_count (unsignedBigInteger default 0),
+  sale_starts_at, sale_ends_at (timestamps nullable),
+  max_per_order (unsignedInteger default 10),
+  attendance_form_id (nullable, FK events_attendance_forms, nullOnDelete),
+  metadata (json nullable),                             -- arbitrary extension data
+  position (unsignedInteger default 0),
+  created_at, updated_at, deleted_at
+
+events_orders
+  id, event_id (FK), user_id (buyer — FK users, cascadeOnDelete),
+  status (string — enum: pending|paid|cancelled|refunded|partially_refunded),
+  subtotal_minor, discount_minor, total_minor (unsignedBigInteger),
+  currency (char(3)),
+  discount_code_id (nullable, FK events_discount_codes, nullOnDelete),
+  processor (string nullable),                          -- e.g. 'stripe'
+  processor_reference (string nullable),                -- gateway charge id
+  paid_at (timestamp nullable),
+  metadata (json nullable),
+  created_at, updated_at, deleted_at
+
+events_order_items
+  id, order_id (FK, cascadeOnDelete),
+  ticket_type_id (FK events_ticket_types, restrictOnDelete),
+  quantity (unsignedInteger),
+  unit_price_minor (unsignedBigInteger),
+  line_total_minor (unsignedBigInteger),
+  created_at, updated_at
+
+events_tickets
+  id, order_item_id (FK events_order_items, cascadeOnDelete),
+  ticket_type_id (FK), event_id (FK),
+  holder_id (FK users, restrictOnDelete),               -- may differ from order.user_id (gifted/transferred)
+  status (string — enum: issued|cancelled|refunded|checked_in|transferred),
+  qr_token (string unique),                             -- signed token for scanning
+  checked_in_at (timestamp nullable),
+  checked_in_by (FK users nullable, nullOnDelete),
+  transferred_from (FK users nullable, nullOnDelete),   -- audit trail for transfers
+  metadata (json nullable),
+  created_at, updated_at, deleted_at
+  index(event_id, status)
+
+events_discount_codes
+  id, code (string unique),
+  description (string nullable),
+  kind (string — enum: percent|fixed),
+  amount_minor (unsignedBigInteger),                    -- percent stored as basis points (1 bp = 0.01%, so 1000 = 10.00%) OR minor units for fixed
+  currency (char(3) nullable),                          -- required when kind=fixed
+  applies_to (string — enum: global|events_subset),
+  starts_at, expires_at (timestamps nullable),
+  max_uses_total (unsignedInteger nullable),
+  max_uses_per_user (unsignedInteger nullable),
+  uses_count (unsignedBigInteger default 0),
+  active (boolean default true),
+  created_at, updated_at, deleted_at
+
+events_discount_code_event             -- pivot when applies_to=events_subset
+  discount_code_id, event_id, primary(discount_code_id, event_id)
+
+events_discount_code_usages
+  id, discount_code_id (FK), order_id (FK), user_id (FK users),
+  applied_minor (unsignedBigInteger), currency (char(3)),
+  created_at, updated_at
+  index(discount_code_id, user_id)                      -- max_uses_per_user query
+```
+
+### 5.3 Attendance
+
+```
+events_attendance_forms                -- reusable forms attached to ticket types
+  id, event_id (FK), name (string),
+  schema (json),                                       -- list of {key,label,type,required,options}
+  created_at, updated_at
+
+events_applications
+  id, event_id (FK), ticket_type_id (FK),
+  applicant_id (FK users, cascadeOnDelete),
+  status (string — enum: pending|approved|rejected|withdrawn|expired),
+  submitted_at (timestamp),
+  decided_at (timestamp nullable),
+  decided_by (FK users nullable, nullOnDelete),
+  decision_note (text nullable),
+
+  -- Paid upfront for application-mode tickets
+  reservation_order_id (nullable, FK events_orders, nullOnDelete),
+
+  metadata (json nullable),
+  created_at, updated_at
+  unique(applicant_id, ticket_type_id)
+  index(status, submitted_at)
+
+events_attendees                       -- a person attending; created when ticket issued
+  id, event_id, ticket_id (FK events_tickets, cascadeOnDelete),
+  user_id (FK users, cascadeOnDelete),
+  status (string — enum: registered|cancelled|checked_in|no_show),
+  profile (json),                                      -- open-ended; suggested keys: name, email, date_of_birth, gender, dietary, t_shirt_size. Consumer defines the shape.
+  created_at, updated_at
+  unique(event_id, user_id)
+
+events_attendance_responses            -- attendee's answers to AttendanceForm
+  id, attendee_id (FK), attendance_form_id (FK),
+  answers (json),                                      -- {question_key: value}
+  created_at, updated_at
+```
+
+### 5.4 Eligibility
+
+```
+events_requirements
+  id, event_id (nullable, FK events_events, cascadeOnDelete),
+  ticket_type_id (nullable, FK events_ticket_types, cascadeOnDelete),
+  type (string — enum: age_min|age_max|document|group_membership|gender|free_form_question|custom_rule),
+  payload (json),                                      -- type-specific config
+  strict (boolean default true),                       -- true = auto-reject on fail; false = flag for organizer
+  position (unsignedInteger default 0),
+  created_at, updated_at
+
+  -- Either event_id or ticket_type_id is set (XOR). Event-level requirements apply to all ticket types;
+  -- type-level requirements override/augment for that type.
+
+events_requirement_checks
+  id, attendee_id (nullable, FK events_attendees, cascadeOnDelete),
+  application_id (nullable, FK events_applications, cascadeOnDelete),
+  requirement_id (FK events_requirements, cascadeOnDelete),
+  status (string — enum: pending|passed|failed|waived),
+  result (json nullable),                              -- engine output / reviewer notes
+  reviewed_by (FK users nullable, nullOnDelete),
+  reviewed_at (timestamp nullable),
+  created_at, updated_at
+  unique(attendee_id, requirement_id)
+  unique(application_id, requirement_id)
+
+events_document_uploads                -- attendees upload IDs / proofs
+  id, attendee_id (FK), requirement_id (FK),
+  kind (string nullable),                              -- 'id_card', 'passport', 'student_card', ...
+  filename (string),                                   -- denormalised; file in medialibrary
+  mime_type (string), byte_size (unsignedBigInteger),
+  metadata (json nullable),                            -- e.g. extracted text, OCR result
+  created_at, updated_at, deleted_at
+
+events_document_verifications
+  id, document_upload_id (FK, cascadeOnDelete),
+  status (string — enum: pending|verified|rejected),
+  decided_by (FK users nullable, nullOnDelete),
+  decided_at (timestamp nullable),
+  note (text nullable),
+  created_at, updated_at
+```
+
+### 5.5 Flow
+
+```
+events_sale_queue_entries              -- waiting-room before sale_starts_at
+  id, event_id (FK), user_id (FK users, cascadeOnDelete),
+  joined_at (timestamp),
+  position (unsignedBigInteger),                       -- absolute order; rebuilt on join
+  released_at (timestamp nullable),                    -- when their turn started
+  expires_at (timestamp nullable),                     -- end of their checkout window
+  last_heartbeat_at (timestamp),
+  status (string — enum: waiting|active|expired|completed|abandoned),
+  created_at, updated_at
+  unique(event_id, user_id)
+  index(event_id, status, position)
+
+events_waitlist_entries                -- after ticket_type sells out
+  id, ticket_type_id (FK), user_id (FK users, cascadeOnDelete),
+  quantity (unsignedInteger),
+  status (string — enum: waiting|offered|claimed|expired),
+  offered_at (timestamp nullable),
+  claim_expires_at (timestamp nullable),
+  created_at, updated_at
+  unique(ticket_type_id, user_id)
+  index(ticket_type_id, status, created_at)
+
+events_refunds
+  id, order_id (FK events_orders, cascadeOnDelete),
+  ticket_id (nullable, FK events_tickets, nullOnDelete),     -- present for partial per-ticket refunds
+  amount_minor (unsignedBigInteger), currency (char(3)),
+  reason (string — enum: rejection|cancelled_event|attendee_request|organizer_initiated|other),
+  reason_note (text nullable),
+  status (string — enum: pending|processed|failed),
+  processor_reference (string nullable),                     -- consumer's payment gateway refund id
+  requested_by (FK users nullable, nullOnDelete),
+  processed_by (FK users nullable, nullOnDelete),
+  processed_at (timestamp nullable),
+  metadata (json nullable),
+  created_at, updated_at
+```
+
+## 6. Enums
+
+```php
+namespace Kurt\Modules\Events\Catalog\Enums;
+enum EventStatus: string { case Draft='draft'; case Published='published'; case Cancelled='cancelled'; case Completed='completed'; }
+enum EventVisibility: string { case Public='public'; case Unlisted='unlisted'; case Private='private'; }
+enum LocationKind: string { case Physical='physical'; case Online='online'; case Hybrid='hybrid'; }
+enum RecurrenceFrequency: string { case None='none'; case Daily='daily'; case Weekly='weekly'; case Monthly='monthly'; case Yearly='yearly'; }
+enum OrganizerRole: string { case Owner='owner'; case Manager='manager'; case Scanner='scanner'; }
+
+namespace Kurt\Modules\Events\Ticketing\Enums;
+enum TicketTypeMode: string { case Open='open'; case Application='application'; case Rsvp='rsvp'; }
+enum OrderStatus: string { case Pending='pending'; case Paid='paid'; case Cancelled='cancelled'; case Refunded='refunded'; case PartiallyRefunded='partially_refunded'; }
+enum TicketStatus: string { case Issued='issued'; case Cancelled='cancelled'; case Refunded='refunded'; case CheckedIn='checked_in'; case Transferred='transferred'; }
+enum DiscountKind: string { case Percent='percent'; case Fixed='fixed'; }
+enum DiscountScope: string { case Global='global'; case EventsSubset='events_subset'; }
+
+namespace Kurt\Modules\Events\Attendance\Enums;
+enum ApplicationStatus: string { case Pending='pending'; case Approved='approved'; case Rejected='rejected'; case Withdrawn='withdrawn'; case Expired='expired'; }
+enum AttendeeStatus: string { case Registered='registered'; case Cancelled='cancelled'; case CheckedIn='checked_in'; case NoShow='no_show'; }
+
+namespace Kurt\Modules\Events\Eligibility\Enums;
+enum RequirementType: string {
+    case AgeMin='age_min'; case AgeMax='age_max';
+    case Document='document'; case GroupMembership='group_membership'; case Gender='gender';
+    case FreeFormQuestion='free_form_question'; case CustomRule='custom_rule';
+}
+enum CheckStatus: string { case Pending='pending'; case Passed='passed'; case Failed='failed'; case Waived='waived'; }
+enum VerificationStatus: string { case Pending='pending'; case Verified='verified'; case Rejected='rejected'; }
+
+namespace Kurt\Modules\Events\Flow\Enums;
+enum QueueStatus: string { case Waiting='waiting'; case Active='active'; case Expired='expired'; case Completed='completed'; case Abandoned='abandoned'; }
+enum WaitlistStatus: string { case Waiting='waiting'; case Offered='offered'; case Claimed='claimed'; case Expired='expired'; }
+enum RefundStatus: string { case Pending='pending'; case Processed='processed'; case Failed='failed'; }
+enum RefundReason: string { case Rejection='rejection'; case CancelledEvent='cancelled_event'; case AttendeeRequest='attendee_request'; case OrganizerInitiated='organizer_initiated'; case Other='other'; }
+```
+
+## 7. Eligibility engine (the tricky part)
+
+### 7.1 Contract
+
+```php
+namespace Kurt\Modules\Events\Eligibility\Contracts;
+
+use Illuminate\Database\Eloquent\Model;
+
+interface RequirementEvaluator
+{
+    /** Returns true when the requirement passes for this attendee. */
+    public function evaluate(Model $attendee, array $payload, array $context = []): CheckResult;
+}
+```
+
+```php
+namespace Kurt\Modules\Events\Eligibility\Engine;
+
+final readonly class CheckResult
+{
+    public function __construct(
+        public bool $passed,
+        public ?string $message = null,
+        public array $data = [],
+    ) {}
+
+    public static function pass(array $data = []): self;
+    public static function fail(string $message, array $data = []): self;
+    public static function pending(string $message = 'Awaiting review'): self;  // for manual review
+}
+```
+
+### 7.2 Default evaluators (shipped)
+
+| Type | Evaluator | Behaviour |
+|---|---|---|
+| `age_min` | `AgeMinEvaluator` | Reads `$attendee->profile['date_of_birth']`. Fails if `< payload.min`. |
+| `age_max` | `AgeMaxEvaluator` | Same but `>`. |
+| `document` | `DocumentEvaluator` | Looks up uploaded document for this requirement. Returns pending until verified (manual or auto via `DocumentVerifier` contract). |
+| `group_membership` | `GroupMembershipEvaluator` | Calls a consumer-supplied `GroupResolver` contract — returns the user's group identifiers. Passes when `payload.group` intersects. |
+| `gender` | `GenderEvaluator` | Reads `$attendee->profile['gender']`. Passes when matches any of `payload.allowed`. |
+| `free_form_question` | `FreeFormEvaluator` | Always returns pending (organizer reviews response manually). |
+| `custom_rule` | `CustomRuleEvaluator` | `payload.evaluator` is the FQCN of a class implementing `RequirementEvaluator`. Module instantiates via container and delegates. |
+
+### 7.3 RequirementEngine
+
+```php
+namespace Kurt\Modules\Events\Eligibility\Engine;
+
+final class RequirementEngine
+{
+    /** Evaluate all requirements attached to a ticket type for a single attendee. */
+    public function evaluateFor(Attendee $attendee, TicketType $ticketType): EvaluationOutcome;
+}
+
+final readonly class EvaluationOutcome
+{
+    public function __construct(
+        public bool $allPassed,
+        public bool $anyStrictFailed,
+        /** @var array<int, RequirementCheck> */
+        public array $checks,
+    ) {}
+}
+```
+
+The engine runs every applicable Requirement, persists `RequirementCheck` rows, and returns an outcome. If `anyStrictFailed`, the consumer should reject the application or refuse the ticket; otherwise the organizer reviews flagged checks.
+
+## 8. Sale queue (waiting-room)
+
+### 8.1 Transport-agnostic design
+
+The queue is a **DB table + a small algorithm**. Clients can interact via:
+- **HTTP polling**: client calls `Events::joinQueue($event, $user)` then polls `Events::queueState($event, $user)` every N seconds.
+- **Broadcasting**: client subscribes to `private-events.queue.{eventId}.user.{userId}`. The module broadcasts `QueueReleased($entry)` when their turn opens.
+
+Both work. The module dispatches `QueueReleased` as a `ShouldBroadcast` event; consumers who don't use broadcasting just rely on polling.
+
+### 8.2 Heartbeat
+
+To keep the queue honest, each waiting user must heartbeat. `Events::queueHeartbeat($entry)` updates `last_heartbeat_at`. A scheduled command `events:prune-queue` marks `status=abandoned` for entries with `last_heartbeat_at < now() - config('events.queue.heartbeat_timeout_seconds', 60)`.
+
+### 8.3 Release algorithm
+
+When `sale_starts_at` is reached, `events:release-queue` runs:
+1. Counts current `active` entries for the event.
+2. Promotes the lowest-`position` `waiting` entries up to `config('events.queue.active_concurrency', 100)` minus current actives.
+3. For each promoted entry, set `status=active`, `released_at=now()`, `expires_at=now() + active_window_seconds`.
+4. Dispatch `QueueReleased(entry)`.
+
+A separate scheduled tick expires `active` entries past `expires_at` and promotes the next waiters.
+
+## 9. Waitlist
+
+When a `TicketType` sells out, users join `events_waitlist_entries`. When a ticket is cancelled/refunded, the top entry is `offered_at = now()`, given a `claim_expires_at`, and dispatched `WaitlistPromoted` (broadcast). Consumer collects their payment; on success calls `Events::claim($waitlistEntry)`. On expiry, next entry is offered.
+
+## 10. Discount codes
+
+### 10.1 Calculation
+
+`PriceCalculator::apply(Order $draftOrder, DiscountCode $code): PriceBreakdown` returns:
+
+```php
+final readonly class PriceBreakdown
+{
+    public int $subtotalMinor;
+    public int $discountMinor;
+    public int $totalMinor;
+    public string $currency;
+}
+```
+
+Percent codes use basis points where 1 bp = 0.01% (so `1000` represents 10.00%). Fixed codes use minor units and must match the order's currency or be rejected.
+
+### 10.2 Limits enforcement
+
+Before applying, the calculator checks:
+- `code.active`
+- `now() between starts_at and expires_at` (if set)
+- `code.uses_count < max_uses_total` (if set)
+- For per-user: `count(discount_code_usages where code_id and user_id) < max_uses_per_user`
+- `applies_to`: global, or event_id ∈ pivot
+
+Failing any check throws a typed `DiscountCodeNotApplicable` exception with reason.
+
+### 10.3 Audit
+
+Every successful application writes a `DiscountCodeUsage` row (code × order × user × applied_amount + timestamp). Admin can query by code, by user, or by event.
+
+## 11. Recurrence + ICS
+
+### 11.1 Recurrence
+
+`recurrence_rule` is a small JSON DSL (subset of RFC 5545 RRULE):
+```json
+{ "frequency": "weekly", "interval": 1, "byDay": ["MO", "WE", "FR"], "count": 12 }
+```
+
+`events:generate-occurrences` runs daily (via the scheduler) and materialises Occurrence rows (which are themselves `Event` rows with `parent_event_id` set) for the next `config('events.recurrence.window_days', 90)` days. Occurrences inherit ticket types from the parent unless overridden.
+
+### 11.2 ICS export
+
+`IcsExporter::forEvent(Event $event): string` returns a VCALENDAR string. `Event::ics()` returns a `Response` with `text/calendar` Content-Type. Used by consumer routes to provide download links — module ships no routes.
+
+## 12. Refunds
+
+`Refund` rows are first-class. Lifecycle:
+
+1. `RefundRequested` dispatched (e.g., from `Events::reject($application, ...)` or `Events::cancel($event, ...)` or `Events::requestRefund($order, ...)`). Row created with `status=pending`.
+2. Consumer listens to `RefundRequested`, calls their payment gateway.
+3. On success: consumer calls `Events::markRefundProcessed($refund, $processorReference)`. Status → `processed`.
+4. On failure: consumer calls `Events::markRefundFailed($refund, $note)`. Status → `failed`. (Admin can retry.)
+
+Order status auto-recomputes after each refund: full refund → `OrderStatus::Refunded`; partial → `OrderStatus::PartiallyRefunded`.
+
+## 13. Domain events
+
+Selection of dispatched events (all under `Kurt\Modules\Events\Events\`):
+
+- Catalog: `EventCreated`, `EventUpdated`, `EventPublished`, `EventCancelled`, `EventCompleted`, `OccurrenceGenerated`.
+- Ticketing: `TicketTypeCreated`, `TicketTypeReleased`, `OrderCreated`, `OrderPaid`, `OrderCancelled`, `OrderRefunded`, `OrderPartiallyRefunded`, `TicketIssued`, `TicketTransferred`, `TicketCheckedIn`, `DiscountCodeApplied`.
+- Attendance: `ApplicationSubmitted`, `ApplicationApproved`, `ApplicationRejected`, `AttendeeRegistered`, `AttendeeCancelled`, `AttendanceFormResponseStored`.
+- Eligibility: `DocumentUploaded`, `DocumentVerified`, `DocumentRejected`, `RequirementCheckPassed`, `RequirementCheckFailed`.
+- Flow: `QueueJoined`, `QueueReleased` (broadcast), `QueueExpired`, `WaitlistJoined`, `WaitlistPromoted` (broadcast), `WaitlistExpired`, `RefundRequested`, `RefundProcessed`, `RefundFailed`.
+
+## 14. Top-level facade
+
+```php
+namespace Kurt\Modules\Events\Support;
+
+use Illuminate\Database\Eloquent\Model;
+use Kurt\Modules\Events\Catalog\Models\Event;
+use Kurt\Modules\Events\Ticketing\Models\{Order, Ticket, TicketType, DiscountCode};
+use Kurt\Modules\Events\Attendance\Models\{Application, Attendee};
+use Kurt\Modules\Events\Flow\Models\{SaleQueueEntry, WaitlistEntry, Refund};
+
+final class Events
+{
+    public function createEvent(array $data, Model $organizer): Event;
+    public function publish(Event $event): void;
+    public function cancel(Event $event, Model $canceller, string $reason): void;
+
+    public function reserve(TicketType $type, Model $buyer, int $quantity, ?string $discountCode = null): Order;
+    public function pay(Order $order, string $processor, string $reference): void;
+    public function transferTicket(Ticket $ticket, Model $newHolder): Ticket;
+    public function checkIn(Ticket $ticket, Model $scanner): Attendee;
+
+    public function apply(TicketType $type, Model $applicant, array $formAnswers = []): Application;
+    public function approve(Application $application, Model $approver): Ticket;
+    public function reject(Application $application, Model $rejector, string $reason): ?Refund;
+
+    public function requestRefund(Order|Ticket $target, Model $requester, RefundReason $reason, ?string $note = null): Refund;
+    public function markRefundProcessed(Refund $refund, string $processorReference): void;
+    public function markRefundFailed(Refund $refund, string $note): void;
+
+    public function joinQueue(Event $event, Model $user): SaleQueueEntry;
+    public function queueHeartbeat(SaleQueueEntry $entry): void;
+    public function joinWaitlist(TicketType $type, Model $user, int $quantity = 1): WaitlistEntry;
+    public function claimWaitlist(WaitlistEntry $entry): Order;
+}
+```
+
+Bound as singleton in the container. A `Kurt\Modules\Events\Facades\Events` facade is a thin wrapper for static call ergonomics (optional).
+
+## 15. Author/attendee traits
+
+```
+Kurt\Modules\Events\Contracts\EventOrganizer
+Kurt\Modules\Events\Contracts\EventAttendee
+Kurt\Modules\Events\Concerns\IsEventOrganizer
+Kurt\Modules\Events\Concerns\IsEventAttendee
+```
+
+Attendee profile fields are app-controlled. The trait exposes `eventTickets()`, `eventOrders()`, `eventApplications()`, `eventAttendances()`, `eventOrganized()`.
+
+## 16. Auth / policies
+
+- `EventPolicy` — view (per visibility), update/delete (organizer with manager+role or staff via `canManageEvents` gate).
+- `TicketTypePolicy` — manage by event organizer.
+- `OrderPolicy` — view by buyer; refund by staff.
+- `ApplicationPolicy` — view+withdraw by applicant; decide by organizer.
+- `RefundPolicy` — request by buyer or staff; process by staff.
+- `QueuePolicy`/`WaitlistPolicy` — join by any auth user (subject to event eligibility).
+
+## 17. Config (`config/events.php`)
+
+```php
+return [
+    'currency' => env('EVENTS_DEFAULT_CURRENCY', 'USD'),
+
+    'queue' => [
+        'enabled' => true,
+        'active_concurrency' => 100,
+        'active_window_seconds' => 300,    // 5-minute checkout slot
+        'heartbeat_timeout_seconds' => 60,
+    ],
+
+    'waitlist' => [
+        'enabled' => true,
+        'claim_window_seconds' => 600,     // 10-minute claim window
+    ],
+
+    'recurrence' => [
+        'enabled' => true,
+        'window_days' => 90,
+    ],
+
+    'documents' => [
+        'disk' => env('EVENTS_DOCUMENT_DISK', 'private'),
+        'verifier' => null,                // FQCN implementing DocumentVerifier; null = manual review
+    ],
+
+    'requirements' => [
+        'evaluators' => [
+            'age_min' => \Kurt\Modules\Events\Eligibility\Evaluators\AgeMinEvaluator::class,
+            'age_max' => \Kurt\Modules\Events\Eligibility\Evaluators\AgeMaxEvaluator::class,
+            'document' => \Kurt\Modules\Events\Eligibility\Evaluators\DocumentEvaluator::class,
+            'group_membership' => \Kurt\Modules\Events\Eligibility\Evaluators\GroupMembershipEvaluator::class,
+            'gender' => \Kurt\Modules\Events\Eligibility\Evaluators\GenderEvaluator::class,
+            'free_form_question' => \Kurt\Modules\Events\Eligibility\Evaluators\FreeFormEvaluator::class,
+            'custom_rule' => \Kurt\Modules\Events\Eligibility\Evaluators\CustomRuleEvaluator::class,
+        ],
+        'group_resolver' => null,          // FQCN implementing GroupResolver; null = no groups
+    ],
+
+    'notifications' => [
+        'enabled' => false,                // opt-in; when true, shipped Notification classes wire up
+        'channels' => ['mail', 'database'],
+    ],
+
+    'broadcasting' => [
+        'enabled' => true,                 // QueueReleased + WaitlistPromoted broadcast
+    ],
+
+    'reminders' => [
+        'enabled' => true,
+        'before_hours' => [24, 1],         // dispatch at T-24h and T-1h
+    ],
+
+    'models' => [
+        // override points for each model, same pattern as Blog/Library
+    ],
+];
+```
+
+## 18. Console commands
+
+- `events:release-queue` — runs every 10 seconds when scheduler is active. Promotes queued users.
+- `events:prune-queue` — marks abandoned heartbeats.
+- `events:expire-waitlist-claims` — runs every minute. Re-offers expired claims to next.
+- `events:generate-occurrences` — daily. Materialises recurring events into the rolling window.
+- `events:dispatch-reminders` — every 5 minutes. Sends reminders for events crossing each `before_hours` threshold.
+- `events:demo` — seeds a sample event, ticket types, discount code, attendees.
+
+## 19. Optional Laravel Notifications
+
+Shipped under `src/Notifications/` (only registered when `config('events.notifications.enabled')`):
+
+- `TicketIssued` (to holder)
+- `EventReminderDue` (to attendees)
+- `ApplicationApproved` (to applicant)
+- `ApplicationRejected` (to applicant)
+- `OrderPaid` (to buyer)
+- `RefundProcessed` (to buyer)
+- `WaitlistOffer` (to user with claim link)
+
+Each uses `via(['mail', 'database'])` by default; consumer can override.
+
+## 20. Filament admin (v1.1)
+
+Resources to ship under `src/Filament/V{3,4,5}/Resources/`:
+
+- `EventResource` (list, create, edit, manage organizers, manage ticket types, manage requirements).
+- `TicketTypeResource` (relation-managed under EventResource).
+- `OrderResource` (read-only main; refund action).
+- `ApplicationResource` (queue view; approve/reject actions).
+- `DiscountCodeResource`.
+- `DocumentVerificationResource` (review queue).
+- `WaitlistResource` (read-only diagnostic).
+- `RefundResource`.
+
+V1.0 ships **headless**. V1.1 adds the resources.
+
+## 21. Testing matrix
+
+### Unit
+- All enums.
+- `PriceCalculator`: discount math (percent + fixed); currency mismatch; over-discount clamped to 0; multi-item orders.
+- `IcsExporter`: recurring + single events.
+- Each requirement evaluator in isolation.
+
+### Feature (Pest + Testbench)
+- Event lifecycle: create → publish → cancel.
+- Open-mode purchase happy path.
+- Application-mode happy path (apply → approve → ticket issued).
+- Application-mode rejection with paid reservation → Refund row created with `status=pending`.
+- Discount code limits: max_uses_total, max_uses_per_user, expired, inactive.
+- Queue: join → release → expire → promote next.
+- Waitlist: sell-out → join → cancel ticket → offer → claim or expire.
+- Recurrence: rule expands to N occurrences over window; idempotent re-runs.
+- ICS download for a single + recurring event.
+- Refund flow end-to-end: requested → processed → order state updates.
+- Eligibility engine: age min/max pass+fail; document upload+verify cycle; custom_rule via stub evaluator; strict vs flag behaviour.
+- Notifications: Mail::fake + Notification::assertSentTo when enabled in config.
+- Broadcasting: Event::fake + assertDispatched for `QueueReleased` + `WaitlistPromoted`.
+
+Coverage target: **70% lines** (lower than Blog/Library/Forum/Chat at 80% because Events is bigger and lifecycle-heavy — many code paths are integration-level).
+
+## 22. Repository setup
+
+The repo `KurtModules-Events` does not yet exist on GitHub. Steps before implementation:
+
+1. Create empty GitHub repo: `https://github.com/OzanKurt/KurtModules-Events`.
+2. `git init` locally at `D:\Code\Projects\KurtModules-Events`.
+3. `git remote add origin https://github.com/OzanKurt/KurtModules-Events`.
+4. Initial commit: `SECURITY.md` (copy from Core) + `LICENSE.md` (MIT, same as siblings).
+5. Push master.
+6. Branch `v1.0` and start the implementation plan from there.
+
+Implementation plan will reference this spec and structure work into ~15 tasks.
+
+## 23. Definition of done (v1.0)
+
+- [ ] Pint + PHPStan level 8 + Pest (≥ 70% line coverage) all green.
+- [ ] CI matrix green on Laravel 12.
+- [ ] All sub-aggregates have at least one feature test exercising the happy path.
+- [ ] Eligibility engine tests cover every shipped evaluator.
+- [ ] Queue release algorithm tested for fairness (position order preserved).
+- [ ] Discount code limits enforced with audit row per usage.
+- [ ] Refund flow end-to-end with payment-gateway hook.
+- [ ] ICS exporter validated against a real calendar (manual verification once).
+- [ ] README + CHANGELOG + LICENSE in place.
+- [ ] Tagged `v1.0.0` after merge to master.
+
+## 24. Open follow-ups (not in v1.0)
+
+- Filament resources (v1.1).
+- Group/role-based ticket pricing (e.g., student discount tied to verified document).
+- Multi-language ticket emails.
+- Per-ticket-type questions during checkout (currently per attendance form attached to type).
+- Stripe Tax / VAT handling — out of scope; consumer's payment integration owns tax.
+- Calendar sync (Google/Outlook OAuth) — out of scope.
+- Geofencing for check-in — out of scope.

--- a/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
+++ b/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
@@ -43,9 +43,9 @@ Code is organised by sub-aggregate, not by technical layer. Each sub-aggregate h
 
 ```
 src/
-  Catalog/                # The event itself + recurrence + organizers + taxonomy
-  Ticketing/              # Ticket types, orders, tickets, discount codes
-  Attendance/             # Attendees, applications, custom forms
+  Catalog/                # Event + Session + recurrence + organizers + taxonomy
+  Ticketing/              # Ticket types, orders, order-item assignments, tickets, transfers, discount codes
+  Attendance/             # Attendees, applications, custom forms, session check-ins
   Eligibility/            # Requirements engine + document verification
   Flow/                   # Queue + waitlist + refunds + reminders
 
@@ -73,6 +73,23 @@ events_categories                    -- optional grouping
 events_tags
   id, slug, name (json — translatable),
   created_at, updated_at
+
+events_sessions                      -- multi-day / multi-session events; ticket types gate by session subset
+  id, event_id (FK events_events, cascadeOnDelete),
+  slug, title (json — translatable), description (json — translatable, nullable),
+  starts_at, ends_at (timestamps),
+  capacity (unsignedInteger nullable),                   -- per-session cap; nullable = inherits event capacity
+  location_name (string nullable),                       -- room/track override for the session
+  position (unsignedInteger default 0),
+  attendees_count (unsignedBigInteger default 0),
+  created_at, updated_at
+  unique(event_id, slug)
+  index(event_id, starts_at)
+
+events_ticket_type_session           -- which sessions a ticket type grants access to; pivot
+  ticket_type_id (FK events_ticket_types, cascadeOnDelete),
+  session_id (FK events_sessions, cascadeOnDelete),
+  primary(ticket_type_id, session_id)
 
 events_events
   id, slug, title (json — translatable), description (json — translatable, nullable),
@@ -126,6 +143,16 @@ events_ticket_types
   sale_starts_at, sale_ends_at (timestamps nullable),
   max_per_order (unsignedInteger default 10),
   attendance_form_id (nullable, FK events_attendance_forms, nullOnDelete),
+
+  -- Transfers
+  transferable (boolean default true),
+  transfer_deadline_hours_before_event (unsignedInteger nullable),  -- null = no cutoff
+  transfer_fee_minor (unsignedBigInteger nullable),                 -- null = free
+  transfer_fee_currency (char(3) nullable),                         -- required when transfer_fee_minor is set
+
+  -- EU consumer-protection refund window
+  consumer_protection_exempt (boolean default false),               -- true for tickets covered by CRD Article 16(l) leisure-event exemption
+
   metadata (json nullable),                             -- arbitrary extension data
   position (unsignedInteger default 0),
   created_at, updated_at, deleted_at
@@ -133,12 +160,17 @@ events_ticket_types
 events_orders
   id, event_id (FK), user_id (buyer — FK users, cascadeOnDelete),
   status (string — enum: pending|paid|cancelled|refunded|partially_refunded),
-  subtotal_minor, discount_minor, total_minor (unsignedBigInteger),
+  subtotal_minor, discount_minor, tax_minor, total_minor (unsignedBigInteger),  -- total = subtotal − discount + tax
+  tax_rate_basis_points (unsignedInteger nullable),     -- e.g. 1900 = 19.00% VAT; nullable when tax not applicable
   currency (char(3)),
   discount_code_id (nullable, FK events_discount_codes, nullOnDelete),
   processor (string nullable),                          -- e.g. 'stripe'
   processor_reference (string nullable),                -- gateway charge id
   paid_at (timestamp nullable),
+
+  -- Group ticket assignment: each OrderItem captures holder pre-payment (see §5.3 + §11.1)
+  assignment_completed_at (timestamp nullable),
+
   metadata (json nullable),
   created_at, updated_at, deleted_at
 
@@ -150,25 +182,48 @@ events_order_items
   line_total_minor (unsignedBigInteger),
   created_at, updated_at
 
+events_order_item_assignments         -- buyer assigns each individual ticket to a holder at checkout
+  id, order_item_id (FK, cascadeOnDelete),
+  seat_index (unsignedInteger),                                  -- 0..quantity-1
+  holder_user_id (FK users, nullable, nullOnDelete),             -- null when registering a guest by email
+  holder_name (string),                                          -- always captured (mirrors user name when set)
+  holder_email (string),                                         -- always captured (mirrors user email when set)
+  holder_metadata (json nullable),                               -- optional profile snapshot per holder
+  created_at, updated_at
+  unique(order_item_id, seat_index)
+
 events_tickets
   id, order_item_id (FK events_order_items, cascadeOnDelete),
+  order_item_assignment_id (nullable, FK events_order_item_assignments, nullOnDelete),
   ticket_type_id (FK), event_id (FK),
-  holder_id (FK users, restrictOnDelete),               -- may differ from order.user_id (gifted/transferred)
+  holder_id (FK users, nullable, nullOnDelete),         -- may differ from order.user_id (gifted/transferred); null for guest holders
+  holder_name (string), holder_email (string),          -- denormalised from assignment for guest tickets
   status (string — enum: issued|cancelled|refunded|checked_in|transferred),
   qr_token (string unique),                             -- signed token for scanning
   checked_in_at (timestamp nullable),
   checked_in_by (FK users nullable, nullOnDelete),
   transferred_from (FK users nullable, nullOnDelete),   -- audit trail for transfers
+  transferred_at (timestamp nullable),
+  transfer_fee_order_id (nullable, FK events_orders, nullOnDelete),  -- when transfer required payment, this is the fee Order
   metadata (json nullable),
   created_at, updated_at, deleted_at
   index(event_id, status)
 
+events_session_check_ins              -- check-in once per (session × ticket)
+  id, session_id (FK events_sessions, cascadeOnDelete),
+  ticket_id (FK events_tickets, cascadeOnDelete),
+  checked_in_at (timestamp),
+  checked_in_by (FK users nullable, nullOnDelete),
+  created_at, updated_at
+  unique(session_id, ticket_id)
+
 events_discount_codes
   id, code (string unique),
   description (string nullable),
-  kind (string — enum: percent|fixed),
-  amount_minor (unsignedBigInteger),                    -- percent stored as basis points (1 bp = 0.01%, so 1000 = 10.00%) OR minor units for fixed
-  currency (char(3) nullable),                          -- required when kind=fixed
+  kind (string — enum: percent|flat_amount),
+  amount_minor (unsignedBigInteger),                    -- percent stored as basis points (1 bp = 0.01%, so 1000 = 10.00%) OR minor units for flat_amount
+  currency (char(3) nullable),                          -- required when kind=flat_amount
+  application_scope (string — enum: order|per_ticket),  -- flat_amount: $5 off the order, or $5 off each ticket?
   applies_to (string — enum: global|events_subset),
   starts_at, expires_at (timestamps nullable),
   max_uses_total (unsignedInteger nullable),
@@ -319,12 +374,14 @@ enum EventVisibility: string { case Public='public'; case Unlisted='unlisted'; c
 enum LocationKind: string { case Physical='physical'; case Online='online'; case Hybrid='hybrid'; }
 enum RecurrenceFrequency: string { case None='none'; case Daily='daily'; case Weekly='weekly'; case Monthly='monthly'; case Yearly='yearly'; }
 enum OrganizerRole: string { case Owner='owner'; case Manager='manager'; case Scanner='scanner'; }
+// Sessions reuse AttendeeStatus for check-in tracking; no dedicated enum needed.
 
 namespace Kurt\Modules\Events\Ticketing\Enums;
 enum TicketTypeMode: string { case Open='open'; case Application='application'; case Rsvp='rsvp'; }
 enum OrderStatus: string { case Pending='pending'; case Paid='paid'; case Cancelled='cancelled'; case Refunded='refunded'; case PartiallyRefunded='partially_refunded'; }
 enum TicketStatus: string { case Issued='issued'; case Cancelled='cancelled'; case Refunded='refunded'; case CheckedIn='checked_in'; case Transferred='transferred'; }
-enum DiscountKind: string { case Percent='percent'; case Fixed='fixed'; }
+enum DiscountKind: string { case Percent='percent'; case FlatAmount='flat_amount'; }
+enum DiscountApplicationScope: string { case Order='order'; case PerTicket='per_ticket'; }
 enum DiscountScope: string { case Global='global'; case EventsSubset='events_subset'; }
 
 namespace Kurt\Modules\Events\Attendance\Enums;
@@ -460,7 +517,13 @@ final readonly class PriceBreakdown
 }
 ```
 
-Percent codes use basis points where 1 bp = 0.01% (so `1000` represents 10.00%). Fixed codes use minor units and must match the order's currency or be rejected.
+**Percent codes** use basis points where 1 bp = 0.01% (so `1000` represents 10.00%) and apply to the order subtotal.
+
+**Flat-amount codes** use minor units in a specific currency. Their `application_scope` selects either:
+- `order` — single flat deduction off the order subtotal.
+- `per_ticket` — deducted from each ticket line (multiplied by item quantity).
+
+Flat-amount codes are rejected when their currency doesn't match the order's currency. (Cross-currency conversion is consumer territory — see §25 follow-ups.)
 
 ### 10.2 Limits enforcement
 
@@ -477,9 +540,44 @@ Failing any check throws a typed `DiscountCodeNotApplicable` exception with reas
 
 Every successful application writes a `DiscountCodeUsage` row (code × order × user × applied_amount + timestamp). Admin can query by code, by user, or by event.
 
-## 11. Recurrence + ICS
+## 11. Group tickets, sessions, and transfers
 
-### 11.1 Recurrence
+### 11.1 Group ticket assignment at checkout
+
+A buyer purchasing N tickets supplies one assignment row per seat (`{name, email, user_id?, metadata?}`). The buyer can:
+- assign a seat to themselves (`user_id = $buyer->id`),
+- assign to a registered user by `user_id`, or
+- assign to a guest by `name + email` (no user account).
+
+Assignment rows persist in `events_order_item_assignments` before payment. On `OrderPaid`, the module issues one Ticket per assignment, copying `holder_*` columns. The buyer can rename/replace assignments while the order is still `pending`; once paid, changes go through the transfer flow.
+
+### 11.2 Multi-session events
+
+`events_sessions` rows belong to an Event. `TicketType::sessions()` BelongsToMany pivots to `events_ticket_type_session`. Selecting a ticket type implicitly grants access to its linked sessions.
+
+Check-in is per-session: `Events::checkInSession(Ticket $ticket, Session $session, User $scanner)` writes an `events_session_check_ins` row (unique on `session_id × ticket_id`). The event-level `Events::checkIn()` remains valid for single-session events; for multi-session events, the session-level call is canonical.
+
+### 11.3 Ticket transfers
+
+Transfer rules per ticket type:
+- `transferable=false` → all transfers rejected.
+- `transfer_deadline_hours_before_event` (nullable) → transfers rejected when `now() > event.starts_at - hours`.
+- `transfer_fee_minor` + `transfer_fee_currency` (nullable) → fee charged before transfer completes.
+
+Flow:
+
+1. `Events::transferTicket(Ticket $ticket, Model $newHolder): Ticket` validates rules.
+2. If a fee is configured: create a single-line fee Order in `pending` status. The returned Ticket has `transfer_fee_order_id` set; `holder_id` is unchanged until payment lands. `TicketTransferRequested` is dispatched.
+3. When `Events::pay($feeOrder, ...)` lands: the ticket's `holder_id` flips, `transferred_from` records the old holder, `transferred_at` is set, `TicketTransferred` is dispatched. Notifications (when enabled) go to both holders.
+4. If no fee: the swap happens immediately and `TicketTransferred` fires.
+
+### 11.4 Tax on Order
+
+`tax_minor` and `tax_rate_basis_points` are populated by the consumer's payment integration (calculated against the buyer's jurisdiction). The module accepts the numbers, persists them, and ensures `total_minor = subtotal_minor − discount_minor + tax_minor`. The module never computes tax itself; consumer payment listeners write the values back via an extension on `Events::pay()` (signature includes optional tax breakdown).
+
+## 12. Recurrence + ICS
+
+### 12.1 Recurrence
 
 `recurrence_rule` is a small JSON DSL (subset of RFC 5545 RRULE):
 ```json
@@ -488,11 +586,11 @@ Every successful application writes a `DiscountCodeUsage` row (code × order × 
 
 `events:generate-occurrences` runs daily (via the scheduler) and materialises Occurrence rows (which are themselves `Event` rows with `parent_event_id` set) for the next `config('events.recurrence.window_days', 90)` days. Occurrences inherit ticket types from the parent unless overridden.
 
-### 11.2 ICS export
+### 12.2 ICS export
 
 `IcsExporter::forEvent(Event $event): string` returns a VCALENDAR string. `Event::ics()` returns a `Response` with `text/calendar` Content-Type. Used by consumer routes to provide download links — module ships no routes.
 
-## 12. Refunds
+## 13. Refunds
 
 `Refund` rows are first-class. Lifecycle:
 
@@ -503,17 +601,34 @@ Every successful application writes a `DiscountCodeUsage` row (code × order × 
 
 Order status auto-recomputes after each refund: full refund → `OrderStatus::Refunded`; partial → `OrderStatus::PartiallyRefunded`.
 
-## 13. Domain events
+### 13.1 EU consumer-protection refund window
+
+The EU Consumer Rights Directive (CRD, 2011/83/EU) gives consumers a 14-day right of withdrawal for most online purchases. **Tickets for "leisure services with a specific date or period of performance"** are exempt under CRD Article 16(l) — concerts, festivals, theatre, sports matches typically qualify and can be marked exempt.
+
+Module behaviour:
+
+- Config: `events.refunds.consumer_protection_window_days` (default `14`; set `0` to disable globally).
+- Per ticket type: `TicketType.consumer_protection_exempt` (default `false`). When `true`, the window does not apply to tickets sold under that type.
+- When an attendee calls `Events::requestRefund($order, ..., RefundReason::AttendeeRequest, ...)` and:
+  - the order was paid within the consumer-protection window AND
+  - no ticket on the order is `consumer_protection_exempt` AND
+  - no ticket on the order has been checked in,
+  then the refund is auto-approved: `Refund::status` skips `pending` review and starts a normal `RefundRequested` flow with a `consumer_protection_eligible=true` flag in `metadata`. The consumer's payment listener processes it as usual.
+- Outside the window, refunds follow organizer-discretion rules (per ticket type's `refundable` flag + organizer approval).
+
+Consumer apps operating outside the EU set the config to `0` to disable; consumer apps inside the EU keep the default. The module itself doesn't infer jurisdiction.
+
+## 14. Domain events
 
 Selection of dispatched events (all under `Kurt\Modules\Events\Events\`):
 
-- Catalog: `EventCreated`, `EventUpdated`, `EventPublished`, `EventCancelled`, `EventCompleted`, `OccurrenceGenerated`.
-- Ticketing: `TicketTypeCreated`, `TicketTypeReleased`, `OrderCreated`, `OrderPaid`, `OrderCancelled`, `OrderRefunded`, `OrderPartiallyRefunded`, `TicketIssued`, `TicketTransferred`, `TicketCheckedIn`, `DiscountCodeApplied`.
+- Catalog: `EventCreated`, `EventUpdated`, `EventPublished`, `EventCancelled`, `EventCompleted`, `OccurrenceGenerated`, `SessionCreated`, `SessionUpdated`, `SessionDeleted`.
+- Ticketing: `TicketTypeCreated`, `TicketTypeReleased`, `OrderCreated`, `OrderPaid`, `OrderCancelled`, `OrderRefunded`, `OrderPartiallyRefunded`, `TicketIssued`, `TicketTransferRequested`, `TicketTransferred`, `TicketCheckedIn`, `SessionCheckedIn`, `DiscountCodeApplied`.
 - Attendance: `ApplicationSubmitted`, `ApplicationApproved`, `ApplicationRejected`, `AttendeeRegistered`, `AttendeeCancelled`, `AttendanceFormResponseStored`.
 - Eligibility: `DocumentUploaded`, `DocumentVerified`, `DocumentRejected`, `RequirementCheckPassed`, `RequirementCheckFailed`.
 - Flow: `QueueJoined`, `QueueReleased` (broadcast), `QueueExpired`, `WaitlistJoined`, `WaitlistPromoted` (broadcast), `WaitlistExpired`, `RefundRequested`, `RefundProcessed`, `RefundFailed`.
 
-## 14. Top-level facade
+## 15. Top-level facade
 
 ```php
 namespace Kurt\Modules\Events\Support;
@@ -530,7 +645,11 @@ final class Events
     public function publish(Event $event): void;
     public function cancel(Event $event, Model $canceller, string $reason): void;
 
-    public function reserve(TicketType $type, Model $buyer, int $quantity, ?string $discountCode = null): Order;
+    /**
+     * @param array<int, array{name: string, email: string, user_id?: int|string|null, metadata?: array<string, mixed>}> $holderAssignments
+     *        One row per seat; length must equal $quantity. Captures group-ticket assignment at checkout time.
+     */
+    public function reserve(TicketType $type, Model $buyer, int $quantity, array $holderAssignments, ?string $discountCode = null): Order;
     public function pay(Order $order, string $processor, string $reference): void;
     public function transferTicket(Ticket $ticket, Model $newHolder): Ticket;
     public function checkIn(Ticket $ticket, Model $scanner): Attendee;
@@ -552,7 +671,7 @@ final class Events
 
 Bound as singleton in the container. A `Kurt\Modules\Events\Facades\Events` facade is a thin wrapper for static call ergonomics (optional).
 
-## 15. Author/attendee traits
+## 16. Author/attendee traits
 
 ```
 Kurt\Modules\Events\Contracts\EventOrganizer
@@ -563,7 +682,7 @@ Kurt\Modules\Events\Concerns\IsEventAttendee
 
 Attendee profile fields are app-controlled. The trait exposes `eventTickets()`, `eventOrders()`, `eventApplications()`, `eventAttendances()`, `eventOrganized()`.
 
-## 16. Auth / policies
+## 17. Auth / policies
 
 - `EventPolicy` — view (per visibility), update/delete (organizer with manager+role or staff via `canManageEvents` gate).
 - `TicketTypePolicy` — manage by event organizer.
@@ -572,7 +691,7 @@ Attendee profile fields are app-controlled. The trait exposes `eventTickets()`, 
 - `RefundPolicy` — request by buyer or staff; process by staff.
 - `QueuePolicy`/`WaitlistPolicy` — join by any auth user (subject to event eligibility).
 
-## 17. Config (`config/events.php`)
+## 18. Config (`config/events.php`)
 
 ```php
 return [
@@ -593,6 +712,18 @@ return [
     'recurrence' => [
         'enabled' => true,
         'window_days' => 90,
+    ],
+
+    'refunds' => [
+        'consumer_protection_window_days' => 14, // EU CRD; set 0 to disable.
+    ],
+
+    'transfers' => [
+        'allowed_by_default' => true,             // overridden per ticket type
+    ],
+
+    'tax' => [
+        'enabled' => true,                        // when false, tax_minor + tax_rate_basis_points stay null
     ],
 
     'documents' => [
@@ -633,7 +764,7 @@ return [
 ];
 ```
 
-## 18. Console commands
+## 19. Console commands
 
 - `events:release-queue` — runs every 10 seconds when scheduler is active. Promotes queued users.
 - `events:prune-queue` — marks abandoned heartbeats.
@@ -642,21 +773,23 @@ return [
 - `events:dispatch-reminders` — every 5 minutes. Sends reminders for events crossing each `before_hours` threshold.
 - `events:demo` — seeds a sample event, ticket types, discount code, attendees.
 
-## 19. Optional Laravel Notifications
+## 20. Optional Laravel Notifications
 
 Shipped under `src/Notifications/` (only registered when `config('events.notifications.enabled')`):
 
 - `TicketIssued` (to holder)
+- `TicketTransferred` (to old holder AND new holder)
 - `EventReminderDue` (to attendees)
 - `ApplicationApproved` (to applicant)
 - `ApplicationRejected` (to applicant)
 - `OrderPaid` (to buyer)
 - `RefundProcessed` (to buyer)
 - `WaitlistOffer` (to user with claim link)
+- `SessionReminderDue` (to attendees of a specific session in a multi-session event)
 
 Each uses `via(['mail', 'database'])` by default; consumer can override.
 
-## 20. Filament admin (v1.1)
+## 21. Filament admin (v1.1)
 
 Resources to ship under `src/Filament/V{3,4,5}/Resources/`:
 
@@ -671,7 +804,7 @@ Resources to ship under `src/Filament/V{3,4,5}/Resources/`:
 
 V1.0 ships **headless**. V1.1 adds the resources.
 
-## 21. Testing matrix
+## 22. Testing matrix
 
 ### Unit
 - All enums.
@@ -681,10 +814,13 @@ V1.0 ships **headless**. V1.1 adds the resources.
 
 ### Feature (Pest + Testbench)
 - Event lifecycle: create → publish → cancel.
-- Open-mode purchase happy path.
+- Open-mode purchase happy path with group ticket assignment (3 holders assigned during one purchase).
 - Application-mode happy path (apply → approve → ticket issued).
 - Application-mode rejection with paid reservation → Refund row created with `status=pending`.
-- Discount code limits: max_uses_total, max_uses_per_user, expired, inactive.
+- Discount code limits: max_uses_total, max_uses_per_user, expired, inactive. Both percent and flat_amount (order + per_ticket scopes).
+- Ticket transfer: free transfer happy path; transfer with fee creates fee Order; transfer rejected after deadline; transfer rejected when type is `transferable=false`.
+- Multi-session: ticket type linked to sessions A+B; check-in for session A is independent of session B; session attendees_count denormalised correctly.
+- EU consumer-protection refund: within window + non-exempt + uncheckedin → auto-approved; exempt type → manual flow; checked-in ticket → manual flow.
 - Queue: join → release → expire → promote next.
 - Waitlist: sell-out → join → cancel ticket → offer → claim or expire.
 - Recurrence: rule expands to N occurrences over window; idempotent re-runs.
@@ -696,7 +832,7 @@ V1.0 ships **headless**. V1.1 adds the resources.
 
 Coverage target: **70% lines** (lower than Blog/Library/Forum/Chat at 80% because Events is bigger and lifecycle-heavy — many code paths are integration-level).
 
-## 22. Repository setup
+## 23. Repository setup
 
 The repo `KurtModules-Events` does not yet exist on GitHub. Steps before implementation:
 
@@ -709,7 +845,7 @@ The repo `KurtModules-Events` does not yet exist on GitHub. Steps before impleme
 
 Implementation plan will reference this spec and structure work into ~15 tasks.
 
-## 23. Definition of done (v1.0)
+## 24. Definition of done (v1.0)
 
 - [ ] Pint + PHPStan level 8 + Pest (≥ 70% line coverage) all green.
 - [ ] CI matrix green on Laravel 12.
@@ -722,7 +858,7 @@ Implementation plan will reference this spec and structure work into ~15 tasks.
 - [ ] README + CHANGELOG + LICENSE in place.
 - [ ] Tagged `v1.0.0` after merge to master.
 
-## 24. Open follow-ups (not in v1.0)
+## 25. Open follow-ups (not in v1.0)
 
 - Filament resources (v1.1).
 - Group/role-based ticket pricing (e.g., student discount tied to verified document).

--- a/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
+++ b/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
@@ -140,10 +140,13 @@ events_ticket_types
   mode (string — enum: open|application|rsvp),
   price_minor (unsignedBigInteger default 0), currency (string char(3) default 'USD'),
   refundable (boolean default true),
+  self_cancel_deadline_hours_before_event (unsignedInteger nullable),  -- buyer self-cancel cutoff; null = organizer-only
   capacity (unsignedInteger nullable),                  -- per-type capacity
   sold_count (unsignedBigInteger default 0),
   sale_starts_at, sale_ends_at (timestamps nullable),
   max_per_order (unsignedInteger default 10),
+  minimum_price_minor (unsignedBigInteger nullable),    -- when set, type is pay-what-you-can; buyer-supplied unit price must be >= this
+  suggested_price_minor (unsignedBigInteger nullable),  -- UI hint for flexible pricing
   attendance_form_id (nullable, FK events_attendance_forms, nullOnDelete),
 
   -- Transfers
@@ -650,8 +653,11 @@ final class Events
     /**
      * @param array<int, array{name: string, email: string, user_id?: int|string|null, metadata?: array<string, mixed>}> $holderAssignments
      *        One row per seat; length must equal $quantity. Captures group-ticket assignment at checkout time.
+     * @param int|null $unitPriceMinorOverride
+     *        Buyer-chosen unit price for pay-what-you-can ticket types. Must be >= ticketType.minimum_price_minor.
+     *        Rejected for fixed-price types.
      */
-    public function reserve(TicketType $type, Model $buyer, int $quantity, array $holderAssignments, ?string $discountCode = null): Order;
+    public function reserve(TicketType $type, Model $buyer, int $quantity, array $holderAssignments, ?string $discountCode = null, ?int $unitPriceMinorOverride = null): Order;
     public function pay(Order $order, string $processor, string $reference): void;
     public function transferTicket(Ticket $ticket, Model $newHolder): Ticket;
     public function checkIn(Ticket $ticket, Model $scanner): Attendee;
@@ -663,6 +669,7 @@ final class Events
     public function reject(Application $application, Model $rejector, string $reason): ?Refund;
 
     public function requestRefund(Order|Ticket $target, Model $requester, RefundReason $reason, ?string $note = null): Refund;
+    public function cancelOrderByBuyer(Order $order, Model $buyer): Refund;  // checks self_cancel_deadline + EU window + uncheckedin
     public function markRefundProcessed(Refund $refund, string $processorReference): void;
     public function markRefundFailed(Refund $refund, string $note): void;
 
@@ -711,7 +718,28 @@ The payload JSON contains `{ticket_id, event_id, issued_at, nonce}`. The HMAC us
 
 When replay protection is on, an `events_check_in_attempts` table records `(ticket_id, scanner_user_id, nonce, ip, user_agent, succeeded, failure_reason, occurred_at)`. Re-presented QR tokens for an already-checked-in ticket return the existing Attendee row but log the duplicate attempt for audit.
 
-### 16.3 Search & discovery scopes
+### 16.3 Concurrency model
+
+`Events::reserve(...)` runs inside `DB::transaction(...)`. Inside the transaction, the ticket type row is locked via `SELECT ... FOR UPDATE` (Eloquent's `->lockForUpdate()`). Capacity is checked against `(capacity - sold_count) >= quantity` before incrementing `sold_count`. The lock prevents two concurrent buyers from oversubscribing the last seats.
+
+The same lock pattern protects `events:expire-pending-orders` when it decrements `sold_count`, and `Events::cancelOrderByBuyer()` when it releases held capacity.
+
+Read-heavy paths (search scopes, listing endpoints) do not lock — they tolerate the brief reservation/cancellation window.
+
+### 16.4 Buyer self-cancellation
+
+`Events::cancelOrderByBuyer(Order $order, Model $buyer)` is the buyer-facing cancellation entry point. It:
+
+1. Verifies `$buyer` is the order's `user_id`.
+2. Verifies the order is in `paid` status (cannot self-cancel pending or already-refunded).
+3. Verifies no ticket on the order is `checked_in`.
+4. Computes the strongest applicable allowance:
+   - **EU consumer-protection** (per §13.1) — within `events.refunds.consumer_protection_window_days` and no `consumer_protection_exempt` tickets.
+   - **Per-type self-cancel deadline** — every ticket on the order belongs to a type whose `self_cancel_deadline_hours_before_event` permits `now()` (or whose value is null, meaning no buyer-side allowance).
+5. If neither allowance applies, throws `SelfCancellationNotPermitted` (typed exception). Buyer can still ask the organizer.
+6. Otherwise creates a `Refund` with `reason=attendee_request`, dispatches `RefundRequested`, and returns the Refund row.
+
+### 16.5 Search & discovery scopes
 
 `Event::class` exposes the following query scopes for consumers building list endpoints:
 
@@ -859,6 +887,14 @@ Shipped under `src/Notifications/` (only registered when `config('events.notific
 - `SessionReminderDue` (to attendees of a specific session in a multi-session event)
 
 Each uses `via(['mail', 'database'])` by default; consumer can override.
+
+Default **Blade Mail templates** ship under `resources/views/notifications/*.blade.php`. Each Notification class uses `(new MailMessage)->view('events::notifications.ticket-issued', [...])`. Consumers publish via:
+
+```bash
+php artisan vendor:publish --tag="events-notifications-views"
+```
+
+Published views land in the app's `resources/views/vendor/events/notifications/` and override the defaults automatically. Markdown templates are not shipped — Blade gives consumers full visual control with their existing brand styles.
 
 ## 22. Filament admin (v1.1)
 

--- a/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
+++ b/docs/superpowers/specs/2026-05-29-kurtmodules-events-v1-spec.md
@@ -99,8 +99,10 @@ events_events
   timezone (string default 'UTC'),
   location_kind (string — enum: physical|online|hybrid),
   location_name (string nullable), location_address (text nullable),
+  latitude (decimal(10,7) nullable), longitude (decimal(10,7) nullable),  -- for nearLocation() scope
   online_url (string nullable),
   cover_path (string nullable),  -- denormalised from medialibrary
+  reminder_intervals (json nullable),  -- nullable = use events.reminders.before_hours global default
 
   -- Recurrence (single events leave both null)
   parent_event_id (nullable, self FK, cascadeOnDelete),  -- for occurrences of a recurring series
@@ -523,7 +525,7 @@ final readonly class PriceBreakdown
 - `order` — single flat deduction off the order subtotal.
 - `per_ticket` — deducted from each ticket line (multiplied by item quantity).
 
-Flat-amount codes are rejected when their currency doesn't match the order's currency. (Cross-currency conversion is consumer territory — see §25 follow-ups.)
+Flat-amount codes are rejected when their currency doesn't match the order's currency. (Cross-currency conversion is consumer territory — see §26 follow-ups.)
 
 ### 10.2 Limits enforcement
 
@@ -653,6 +655,8 @@ final class Events
     public function pay(Order $order, string $processor, string $reference): void;
     public function transferTicket(Ticket $ticket, Model $newHolder): Ticket;
     public function checkIn(Ticket $ticket, Model $scanner): Attendee;
+    public function checkInByToken(string $qrToken, Model $scanner): Attendee;
+    public function checkInSession(Ticket $ticket, Session $session, Model $scanner): SessionCheckIn;
 
     public function apply(TicketType $type, Model $applicant, array $formAnswers = []): Application;
     public function approve(Application $application, Model $approver): Ticket;
@@ -671,7 +675,57 @@ final class Events
 
 Bound as singleton in the container. A `Kurt\Modules\Events\Facades\Events` facade is a thin wrapper for static call ergonomics (optional).
 
-## 16. Author/attendee traits
+## 16. Behaviour details
+
+### 16.1 Capacity holds & cart abandonment
+
+Capacity is held the moment `Events::reserve(...)` runs: the module increments `ticket_types.sold_count` and `events.tickets_sold_count` immediately, before payment lands. This prevents over-selling during peak load. The relationship of `sold_count` is therefore **"reserved + paid"**, not "paid only".
+
+`Events::expirePendingOrders()` (run by the `events:expire-pending-orders` command every minute) finds orders with `status=pending` and `created_at < now() - events.orders.pending_timeout_minutes` and:
+
+1. Sets `Order.status = OrderStatus::Cancelled`.
+2. Decrements `ticket_types.sold_count` and `events.tickets_sold_count` by the order's quantities.
+3. Removes any `events_order_item_assignments` rows (we don't need to keep abandoned holder data).
+4. Dispatches `OrderCancelled` with reason `cart_timeout`.
+
+Manual cancellation by buyer or admin follows the same release path.
+
+### 16.2 QR check-in tokens
+
+`Ticket.qr_token` is a **signed payload** generated when the ticket is issued. Format:
+
+```
+base64url( payload_json ) . "." . hex( hmac_sha256( payload_json, app_key ) )
+```
+
+The payload JSON contains `{ticket_id, event_id, issued_at, nonce}`. The HMAC uses `config('app.key')`. The full string is what gets encoded into the QR image.
+
+`Events::checkInByToken(string $qrToken, Model $scanner)`:
+
+1. Splits at `.` into payload + signature.
+2. Recomputes HMAC; rejects on mismatch.
+3. Decodes payload; loads ticket; verifies `event_id` matches and ticket status is `issued`.
+4. If `events.check_in.token_lifetime_minutes > 0`, rejects when `issued_at` is too old.
+5. If `events.check_in.replay_protection`, logs the attempt with `nonce`; rejects when the nonce was used before (per `events_check_in_attempts` table, see below).
+6. Calls existing `Events::checkIn($ticket, $scanner)` to mark `checked_in_at` and return Attendee.
+
+When replay protection is on, an `events_check_in_attempts` table records `(ticket_id, scanner_user_id, nonce, ip, user_agent, succeeded, failure_reason, occurred_at)`. Re-presented QR tokens for an already-checked-in ticket return the existing Attendee row but log the duplicate attempt for audit.
+
+### 16.3 Search & discovery scopes
+
+`Event::class` exposes the following query scopes for consumers building list endpoints:
+
+- `scopePublished(Builder $q)` — `status = published` and `cancelled_at is null`.
+- `scopeUpcoming(Builder $q)` — `starts_at >= now()`.
+- `scopePast(Builder $q)` — `starts_at < now()`.
+- `scopeInCategory(Builder $q, Category|int $category)`.
+- `scopeWithTags(Builder $q, array|int $tagIds, bool $matchAll = false)`.
+- `scopeNearLocation(Builder $q, float $lat, float $lng, float $radius)` — Haversine SQL via raw expression; requires `latitude`/`longitude` populated and `events.search.geo.enabled = true`. Distance unit comes from `events.search.geo.distance_unit`.
+- `scopeOrganizedBy(Builder $q, Model $user)` — events the user organizes.
+
+Scout adapter ships in v1.1 as a follow-up; v1.0 is scope-only.
+
+## 17. Author/attendee traits
 
 ```
 Kurt\Modules\Events\Contracts\EventOrganizer
@@ -682,7 +736,7 @@ Kurt\Modules\Events\Concerns\IsEventAttendee
 
 Attendee profile fields are app-controlled. The trait exposes `eventTickets()`, `eventOrders()`, `eventApplications()`, `eventAttendances()`, `eventOrganized()`.
 
-## 17. Auth / policies
+## 18. Auth / policies
 
 - `EventPolicy` — view (per visibility), update/delete (organizer with manager+role or staff via `canManageEvents` gate).
 - `TicketTypePolicy` — manage by event organizer.
@@ -691,7 +745,7 @@ Attendee profile fields are app-controlled. The trait exposes `eventTickets()`, 
 - `RefundPolicy` — request by buyer or staff; process by staff.
 - `QueuePolicy`/`WaitlistPolicy` — join by any auth user (subject to event eligibility).
 
-## 18. Config (`config/events.php`)
+## 19. Config (`config/events.php`)
 
 ```php
 return [
@@ -755,7 +809,23 @@ return [
 
     'reminders' => [
         'enabled' => true,
-        'before_hours' => [24, 1],         // dispatch at T-24h and T-1h
+        'before_hours' => [24, 1],         // global default; events.reminder_intervals overrides per event
+    ],
+
+    'orders' => [
+        'pending_timeout_minutes' => 15,   // cart abandonment cutoff; orders past this are auto-cancelled
+    ],
+
+    'check_in' => [
+        'token_lifetime_minutes' => 0,     // 0 = no expiry; QR tokens valid for the event window
+        'replay_protection' => true,       // log every check-in attempt for audit / replay defence
+    ],
+
+    'search' => [
+        'geo' => [
+            'enabled' => false,            // when true, nearLocation() scope assumes latitude/longitude populated on events
+            'distance_unit' => 'km',
+        ],
     ],
 
     'models' => [
@@ -764,16 +834,17 @@ return [
 ];
 ```
 
-## 19. Console commands
+## 20. Console commands
 
 - `events:release-queue` — runs every 10 seconds when scheduler is active. Promotes queued users.
 - `events:prune-queue` — marks abandoned heartbeats.
 - `events:expire-waitlist-claims` — runs every minute. Re-offers expired claims to next.
 - `events:generate-occurrences` — daily. Materialises recurring events into the rolling window.
-- `events:dispatch-reminders` — every 5 minutes. Sends reminders for events crossing each `before_hours` threshold.
+- `events:dispatch-reminders` — every 5 minutes. Sends reminders for events crossing each `before_hours` threshold (per-event override read from `events.reminder_intervals`).
+- `events:expire-pending-orders` — every minute. Cancels orders stuck in `pending` past `events.orders.pending_timeout_minutes` and releases held capacity.
 - `events:demo` — seeds a sample event, ticket types, discount code, attendees.
 
-## 20. Optional Laravel Notifications
+## 21. Optional Laravel Notifications
 
 Shipped under `src/Notifications/` (only registered when `config('events.notifications.enabled')`):
 
@@ -789,7 +860,7 @@ Shipped under `src/Notifications/` (only registered when `config('events.notific
 
 Each uses `via(['mail', 'database'])` by default; consumer can override.
 
-## 21. Filament admin (v1.1)
+## 22. Filament admin (v1.1)
 
 Resources to ship under `src/Filament/V{3,4,5}/Resources/`:
 
@@ -804,7 +875,7 @@ Resources to ship under `src/Filament/V{3,4,5}/Resources/`:
 
 V1.0 ships **headless**. V1.1 adds the resources.
 
-## 22. Testing matrix
+## 23. Testing matrix
 
 ### Unit
 - All enums.
@@ -832,7 +903,7 @@ V1.0 ships **headless**. V1.1 adds the resources.
 
 Coverage target: **70% lines** (lower than Blog/Library/Forum/Chat at 80% because Events is bigger and lifecycle-heavy — many code paths are integration-level).
 
-## 23. Repository setup
+## 24. Repository setup
 
 The repo `KurtModules-Events` does not yet exist on GitHub. Steps before implementation:
 
@@ -845,7 +916,7 @@ The repo `KurtModules-Events` does not yet exist on GitHub. Steps before impleme
 
 Implementation plan will reference this spec and structure work into ~15 tasks.
 
-## 24. Definition of done (v1.0)
+## 25. Definition of done (v1.0)
 
 - [ ] Pint + PHPStan level 8 + Pest (≥ 70% line coverage) all green.
 - [ ] CI matrix green on Laravel 12.
@@ -858,7 +929,7 @@ Implementation plan will reference this spec and structure work into ~15 tasks.
 - [ ] README + CHANGELOG + LICENSE in place.
 - [ ] Tagged `v1.0.0` after merge to master.
 
-## 25. Open follow-ups (not in v1.0)
+## 26. Open follow-ups (not in v1.0)
 
 - Filament resources (v1.1).
 - Group/role-based ticket pricing (e.g., student discount tied to verified document).

--- a/docs/superpowers/specs/2026-05-29-kurtmodules-v2-x-enhancements-spec.md
+++ b/docs/superpowers/specs/2026-05-29-kurtmodules-v2-x-enhancements-spec.md
@@ -1,0 +1,127 @@
+# KurtModules v2.x — Enhancements Roadmap
+
+**Date:** 2026-05-29
+**Status:** Draft → user review pending
+**Family:** [KurtModules v2 umbrella](./2026-05-28-kurtmodules-v2-design.md)
+
+---
+
+## 1. Purpose
+
+The existing five modules (Core, Blog, Chat, Forum, Library) shipped v2.0.0. Chat already advanced to v2.1.0 with musonza/cmgmyr-inspired features. This spec catalogues the next-up enhancements for each module across v2.x point releases.
+
+Each item is sized to fit a single PR. Items are tagged with a target version. Filament admin (planned for every module) is the long-running thread tying versions together.
+
+## 2. Core (`ozankurt/laravel-modules-core`)
+
+### v2.1
+- **`AuditedByUser` trait** — `audit_created_by`, `audit_updated_by` columns + observer wiring. Reused by Blog/Forum/Library/Events for tracking who last touched a record.
+- **`HasUuids` opt-in trait** — wraps the bigint→UUID switch via module config. Satisfies the umbrella spec §4.5 ("UUID opt-in via config"). Modules use the trait when their config opts in.
+- **`AsEnum` cast helper** — sugar for null-safe enum casts; saves boilerplate in modules.
+
+### v2.2
+- **`spatie/laravel-activitylog` adapter** — opt-in subscriber that maps shipped domain events from sibling modules to activity log rows. Off by default.
+- **`SettingsBag` helper** — small abstraction for per-module settings stored in a `kurtmodules_settings` JSON table, useful when consumers want config writable at runtime.
+
+## 3. Blog (`ozankurt/laravel-modules-blog`)
+
+### v2.1
+- **Reading-time accessor** — `Post::readingTime(): int` from body word count + config-driven WPM. Free.
+- **Auto-related posts** — `Post::related(int $limit = 5)`. Same category or shared tags, scored.
+- **Filament v3 resources** — `PostResource`, `CategoryResource`, `TagResource`, `CommentResource` for Filament 3 only. v4/v5 ship in v2.2.
+
+### v2.2
+- **Series/Collections** — `blog_series` table + `blog_post_series` pivot. `Series` model with translatable name + description; `Post::series()` BelongsToMany.
+- **Co-authors** — `blog_post_authors` pivot replaces single `user_id` semantics. Backward-compatible accessor on Post returns first co-author when only one.
+- **Comment threading > 1 level** — expose `blog.comment_max_depth` config and remove the hard cap.
+- **Filament v4 + v5 resources** — parallel to v3.
+
+### v2.3
+- **Scout search adapter** — optional dep on `laravel/scout`. Indexes Post + Category + Tag.
+- **RSS/Atom feed helper** — `Post::feed()` returns a `RssFeed` value object the consumer can render.
+
+## 4. Library (`ozankurt/laravel-modules-library`)
+
+### v2.1
+- **Item ratings + reviews** — `library_ratings` (1-5 star) + `library_reviews` (text). Aggregate on Item: `avg_rating`, `ratings_count`. Recompute via observer.
+- **Bookmarks / favorites** — `library_bookmarks` table; per-user. Trait `HasLibraryBookmarks` exposes `bookmarkedItems()`.
+- **Shareable links with TTL** — `Item::shareableUrl(int $expiresInSeconds = 86400)` returns a signed URL referencing a tokenized download/view route. Module ships the route under an opt-in `library.share_links.route_enabled`.
+- **Recently accessed / trending** — `Item::scopeRecentlyAccessed`, `Item::scopeTrending(int $days = 7)`. Read from `access_log`.
+- **Filament v3 resources** — `FolderResource`, `ItemResource` (with version + permission relation managers), `TagResource`, `AccessLogResource`.
+
+### v2.2
+- **Full-text search via Scout** — Item title/description/tags indexed.
+- **Item recommendations** — simple "users who viewed this also viewed" using access_log.
+- **Filament v4 + v5 resources**.
+
+## 5. Forum (`ozankurt/laravel-modules-forum`)
+
+### v2.1
+- **Best answer** — `forum_threads.accepted_answer_id` (FK forum_posts) + `Thread::markAccepted(Post)` + `Thread::clearAccepted()`. Awarder rule: `AcceptedAnswerBadge`.
+- **Quote replies** — `Post::quoteOf(Post): self` helper. Renders excerpt prefix into body.
+- **Mention extraction** — reuse Chat's `MentionExtractor` (move it to Core in v2.2 — see §2). v2.1 ships a local copy or vendor-installs Chat as an opt-in dep.
+- **Filament v3 resources** — Board, Thread, Post, ModerationReport, Badge, UserBadge.
+
+### v2.2
+- **Reputation / karma** — `forum_user_reputation` table; events `VoteCast`/`VoteRevoked` adjust. Decay job optional. Badge rules pivot to reputation-based.
+- **Polls in threads** — `forum_polls` + `forum_poll_options` + `forum_poll_votes`. `Thread::poll(): ?Poll`.
+- **Thread tags** — `forum_tags` + `forum_thread_tag` pivot, distinct from boards.
+- **Filament v4 + v5 resources**.
+
+### v2.3
+- **Email digest for subscriptions** — daily/weekly summaries via Mail; opt-in per subscription.
+
+## 6. Chat (`ozankurt/laravel-modules-chat`)
+
+v2.1 shipped enhancements (archive, system messages, flags, cursor pagination, encryption, ChatParticipant trait). The next slot is for items deferred from v2.1.
+
+### v2.2
+- **User-level blocks** — `chat_blocks` table (`blocker_id`, `blocked_id`). Conversation filtering scope `excludeBlockedBy(User)`.
+- **Message edit history** — `chat_message_edits` audit table (`message_id`, `old_body`, `edited_by`, `edited_at`).
+- **Pinned messages per conversation** — `chat_message_pins` table. Helper `Conversation::pin(Message, by: User)`.
+- **Scheduled messages** — `chat_messages.send_at` column. `chat:dispatch-scheduled` command releases due rows + dispatches `MessageSent`.
+- **Read-receipts helper** — `Message::readBy()` returns participants whose `last_read_at >= $this->created_at`.
+- **Filament v3 resources** — Conversation, Message (moderation queue), Presence.
+
+### v2.3
+- **Filament v4 + v5 resources**.
+- **Reaction analytics** — top reactions per conversation, per period.
+
+## 7. Cross-module follow-up: Packagist publishing
+
+Currently all six packages (Core/Blog/Chat/Forum/Library/Events) install from GitHub via VCS repository declarations. Move each to Packagist:
+
+1. Submit `https://github.com/OzanKurt/KurtModules-Core` at https://packagist.org/packages/submit.
+2. Configure the GitHub webhook so future tags auto-update.
+3. Repeat for Blog/Chat/Forum/Library/Events.
+4. Each downstream module drops its `"repositories": [{ "type": "vcs", "url": "..." }]` entry in a follow-up PR.
+
+This is one user-action per repo. Document in CONTRIBUTING.md.
+
+## 8. Coordination
+
+- Each enhancement is a separate PR on the module's repo, branching from `master`. Tag at the end with the bump (`v2.1.0`, `v2.2.0`).
+- Cross-cutting items (Mention extractor moving to Core, Activity log adapter) happen in **Core first**, then downstream modules upgrade their Core constraint and consume it.
+- Filament v3 lands per module ahead of v4/v5 because v3 is most mature and most documented; v4 and v5 ship together in the next slot.
+
+## 9. Out of scope for v2.x
+
+- Major API redesigns (would be v3.x).
+- Cross-module bridges (Blog ↔ Forum comments etc.). Spec §3 of the umbrella forbids cross-module deps.
+- Public-facing Blade views in any module. Headless + Filament admin only.
+- `spatie/laravel-permission` requirement anywhere. Stays Gates/Policies.
+
+## 10. Definition of done per module bump
+
+- [ ] All shipped tests still pass.
+- [ ] New tests cover every added public method/scope.
+- [ ] Pint + PHPStan level 8 clean.
+- [ ] CHANGELOG entry under the new version.
+- [ ] UPGRADE notes when migrations introduce schema changes.
+- [ ] Tag + GitHub release.
+
+## 11. References
+
+- [Umbrella v2 design](./2026-05-28-kurtmodules-v2-design.md)
+- [Events v1 spec](./2026-05-29-kurtmodules-events-v1-spec.md)
+- Per-module v2 specs in the same `specs/` directory.

--- a/docs/superpowers/specs/2026-05-30-kurtmodules-media-library-v1-spec.md
+++ b/docs/superpowers/specs/2026-05-30-kurtmodules-media-library-v1-spec.md
@@ -1,0 +1,837 @@
+# `ozankurt/laravel-modules-media-library` v1.0 — Spec
+
+**Repo:** `KurtModules-MediaLibrary` (to be created)
+**Date:** 2026-05-30
+**Status:** Draft → user review pending
+**Family:** [KurtModules v2 umbrella](./2026-05-28-kurtmodules-v2-design.md)
+
+---
+
+## 1. Purpose
+
+A **WordPress-style central media bucket** for Laravel SaaS apps. Headless backend that wraps `spatie/laravel-medialibrary` as the storage engine and adds:
+
+- Tenant-aware ownership (User / Team / Organization via polymorphic owner).
+- Nested folder tree with per-folder ACL (same shape as ResourceLibrary).
+- WordPress-flavour item metadata (title / alt / caption / description / focal point / blurhash / dominant color / palette / EXIF / AI tags).
+- Named-preset + ad-hoc conversions with focal-point-aware cropping.
+- Versioning with stable item IDs so polymorphic links survive replacements.
+- Polymorphic many-to-many attachment to any consumer model with roles (cover / gallery / social / attachment / etc.).
+- Server-proxy AND direct-to-S3 upload flows.
+- Public share links with TTL + revoke + access log.
+- Tag taxonomy, structured filters, saved searches.
+- Optional Scout / EXIF / OCR / AI tagger / blurhash / palette extractor contracts (no third-party calls in module).
+
+v1.0 is **headless**. Filament v3/v4/v5 admin (a WordPress-grid-style UI) lands in v1.1.
+
+## 2. Family relationship
+
+Sibling to Core/Blog/Library/Forum/Chat/Events. Same conventions per the [umbrella v2 design](./2026-05-28-kurtmodules-v2-design.md). Depends on Core only. **Companion change**: existing `ozankurt/laravel-modules-library` v2 is renamed to `ozankurt/laravel-modules-resource-library` v3 — see [Library rename spec](./2026-05-30-kurtmodules-resource-library-rename-spec.md).
+
+## 3. Stack & metadata
+
+| | |
+|---|---|
+| Composer name | `ozankurt/laravel-modules-media-library` |
+| PHP namespace | `Kurt\Modules\MediaLibrary\` |
+| Table prefix | `media_library_` |
+| PHP | `^8.4` |
+| Laravel | `^12.0 \|\| ^13.0` |
+| Core | `ozankurt/laravel-modules-core: ^2.0` |
+| Spatie media | `spatie/laravel-medialibrary: ^11.0` (hard runtime dep — storage engine) |
+| Translatable | `spatie/laravel-translatable: ^6.11` |
+| Sluggable | `cviebrock/eloquent-sluggable: ^11.0 \|\| ^12.0` |
+| Image processing | `intervention/image: ^3.0` |
+| Filament | `^3.0 \|\| ^4.0 \|\| ^5.0` (require-dev; resources land v1.1) |
+| Tests | Pest 3 + Testbench + PHPStan 8 + Pint, GH Actions CI |
+
+## 4. Architecture: 5 sub-areas + cross-cutting
+
+Code is organised by responsibility, not technical layer:
+
+```
+src/
+  Catalog/                  # Items, folders, tags, owner relationships
+    Enums/{Visibility, ItemKind, AttachmentRole}.php
+    Models/{MediaLibraryItem, MediaLibraryFolder, MediaLibraryTag, MediaLibraryAttachment, MediaLibrarySavedSearch, MediaLibraryStorage}.php
+    Observers/{MediaLibraryItemObserver, MediaLibraryFolderObserver}.php
+    Support/{FolderPathBuilder, ItemSlugger}.php
+  Storage/                  # Spatie integration + uploads + conversions + variants + versions
+    Enums/{PendingUploadStatus}.php
+    Models/{MediaLibraryVersion, MediaLibraryVariant, MediaLibraryPendingUpload}.php
+    Support/{UploadCoordinator, ConversionEngine, VariantGenerator, FocalPointCropper, ReplaceCoordinator}.php
+    Contracts/{ExifExtractor, OcrExtractor, AiTagger, BlurhashGenerator, PaletteExtractor}.php
+    Extractors/{DefaultExifExtractor, InterventionBlurhashGenerator, InterventionPaletteExtractor}.php
+  Sharing/                  # Share links + access log
+    Enums/{ShareAbility, AccessAction}.php
+    Models/{ShareLink, AccessLogEntry}.php
+    Support/{ShareLinkSigner, ShareLinkResolver}.php
+  Access/                   # Folder ACL — reuses ResourceLibrary's pattern
+    Models/{FolderPermission}.php
+    Contracts/{MediaSubjectResolver}.php
+    Support/{DefaultSubjectResolver, FolderPermissionResolver, MediaLibraryAccess}.php
+    Values/Subject.php
+  Search/                   # Default DB scopes + Scout adapter
+    Contracts/ScoutAdapter.php
+    Support/DefaultSearchEngine.php
+
+  Concerns/                 # Consumer-side traits
+    HasMediaLibraryItems.php
+    IsMediaLibraryOwner.php
+  Contracts/                # Person-side contracts
+    MediaLibraryOwner.php
+  Console/Commands/
+  Events/                   # Domain events (Laravel events)
+  Exceptions/
+  Notifications/            # Optional Laravel Notifications
+  Policies/
+  Providers/MediaLibraryServiceProvider.php
+  Support/MediaLibrary.php  # Top-level facade
+  Facades/MediaLibrary.php  # Thin facade
+```
+
+## 5. Data model
+
+All tables: `bigIncrements` id, `softDeletes()` where domain rows, `timestamps()`. JSON for translatable text + flexible metadata. Money / count columns use `unsignedBigInteger` / `unsignedInteger`.
+
+### 5.1 Catalog
+
+```
+media_library_folders                -- owner-scoped nested folder tree
+  id, owner_type (string), owner_id (unsignedBigInteger),
+  parent_id (nullable, self FK, restrictOnDelete),
+  slug (string), name (json — translatable), description (json — translatable, nullable),
+  path (string indexed),                                  -- e.g. /clients/acme/2026
+  depth (unsignedInteger default 0),
+  position (unsignedInteger default 0),
+  visibility (string — enum: private|restricted|public, default 'private'),
+  item_count (unsignedBigInteger default 0),              -- denormalised, direct items
+  descendant_count (unsignedBigInteger default 0),        -- denormalised, recursive
+  created_by (FK users nullable, nullOnDelete),
+  created_at, updated_at, deleted_at
+  unique(owner_type, owner_id, parent_id, slug)
+  index(owner_type, owner_id, path)
+
+media_library_items                  -- WordPress-style media row
+  id, owner_type, owner_id,
+  folder_id (nullable, FK media_library_folders, nullOnDelete),
+  storage_id (FK media_library_storage, cascadeOnDelete),  -- thin HasMedia host (see §5.2)
+  slug (string, owner-scoped unique),
+  title (json — translatable), alt_text (json — translatable, nullable),
+  caption (json — translatable, nullable), description (json — translatable, nullable),
+  filename (string),                                       -- original filename for display + downloads
+  mime_type (string),
+  byte_size (unsignedBigInteger),
+  width (unsignedInteger nullable), height (unsignedInteger nullable),
+  duration_seconds (decimal(8,3) nullable),                -- audio/video
+  focal_x (decimal(4,3) default 0.500),                    -- 0..1
+  focal_y (decimal(4,3) default 0.500),
+  dominant_color (string char(7) nullable),                -- '#rrggbb'
+  palette (json nullable),                                 -- ['#hex', ...]
+  blurhash (string nullable),
+  exif (json nullable),
+  ai_tags (json nullable),
+  extracted_text (text nullable),                          -- OCR
+  download_count (unsignedBigInteger default 0),
+  view_count (unsignedBigInteger default 0),
+  metadata (json nullable),
+  created_by (FK users nullable, nullOnDelete),
+  updated_by (FK users nullable, nullOnDelete),
+  created_at, updated_at, deleted_at
+  unique(owner_type, owner_id, slug)
+  index(owner_type, owner_id, folder_id)
+  index(mime_type)
+
+media_library_storage                -- one thin HasMedia host row per item; isolates our spatie collection from consumer's
+  id, item_uid (uuid, unique),                             -- used for spatie collection routing
+  created_at, updated_at
+
+media_library_tags
+  id, owner_type, owner_id,
+  slug, name (json — translatable),
+  color (string nullable),
+  position (unsignedInteger default 0),
+  created_at, updated_at
+  unique(owner_type, owner_id, slug)
+
+media_library_item_tag               -- pivot
+  item_id, tag_id, primary(item_id, tag_id)
+
+media_library_attachments            -- polymorphic many-to-many to consumer models
+  id, item_id (FK media_library_items, cascadeOnDelete),
+  attachable_type (string), attachable_id (unsignedBigInteger),
+  role (string default 'attachment'),                      -- cover|gallery|social|attachment|...
+  position (unsignedInteger default 0),
+  created_at, updated_at
+  index(attachable_type, attachable_id, role)
+  index(item_id)
+
+media_library_saved_searches
+  id, user_id (FK users, cascadeOnDelete),
+  name (string), filters (json),
+  created_at, updated_at
+```
+
+### 5.2 Storage
+
+```
+media_library_versions               -- audit of file replacements per item
+  id, item_id (FK media_library_items, cascadeOnDelete),
+  spatie_media_id (unsignedBigInteger),                    -- points at the prior spatie media row; not constrained because spatie's row may be hard-deleted later
+  filename (string), mime_type (string), byte_size (unsignedBigInteger),
+  changelog (text nullable),
+  created_by (FK users nullable, nullOnDelete),
+  created_at, updated_at
+
+media_library_variants               -- ad-hoc derived images cached for reuse
+  id, item_id (FK media_library_items, cascadeOnDelete),
+  key (string),                                            -- canonical key from spec, e.g. '300x200-crop-focal'
+  spec (json),                                             -- width, height, fit, focal, format, quality
+  path (string),                                           -- relative path on disk
+  mime_type (string), byte_size (unsignedBigInteger),
+  last_used_at (timestamp nullable),
+  generated_at (timestamp),
+  created_at, updated_at
+  unique(item_id, key)
+
+media_library_pending_uploads        -- presigned-S3 in-flight uploads
+  id, owner_type, owner_id,
+  upload_id (uuid, unique),
+  filename (string), mime_type (string), byte_size (unsignedBigInteger nullable),
+  driver (string default 's3'),
+  driver_payload (json),                                   -- presigned URL + fields + key
+  status (string — enum: pending|completed|cancelled|expired),
+  completed_at (timestamp nullable), expires_at (timestamp),
+  created_by (FK users nullable, nullOnDelete),
+  created_at, updated_at
+  index(status, expires_at)
+```
+
+### 5.3 Sharing
+
+```
+media_library_share_links
+  id, item_id (nullable, FK media_library_items, cascadeOnDelete),
+  folder_id (nullable, FK media_library_folders, cascadeOnDelete),  -- XOR with item_id
+  token (string unique),                                  -- url-safe random 32 chars
+  abilities (json),                                       -- ['view'] or ['view','download']
+  invitee_email (string nullable),
+  expires_at (timestamp nullable),                        -- null = no expiry
+  revoked_at (timestamp nullable),
+  access_count (unsignedBigInteger default 0),
+  last_accessed_at (timestamp nullable),
+  last_accessed_ip (string nullable),
+  created_by (FK users nullable, nullOnDelete),
+  created_at, updated_at, deleted_at
+
+media_library_access_log
+  id, item_id (nullable, FK media_library_items, cascadeOnDelete),
+  share_link_id (nullable, FK media_library_share_links, nullOnDelete),
+  user_id (nullable, FK users, nullOnDelete),
+  action (string — enum: view|download|upload|replace|delete),
+  ip (string nullable), user_agent (string nullable),
+  occurred_at (timestamp indexed),
+  created_at, updated_at
+```
+
+### 5.4 Access (folder ACL)
+
+```
+media_library_folder_permissions     -- same shape as resource library
+  id, folder_id (FK media_library_folders, cascadeOnDelete),
+  subject_type (string — enum: user|role|everyone),
+  subject_value (string nullable),                        -- user id (string), role name, or null for 'everyone'
+  capability (string — enum: view|download|manage),
+  cascade (boolean default true),
+  created_at, updated_at
+  index(folder_id, subject_type, subject_value)
+```
+
+## 6. Enums
+
+```php
+namespace Kurt\Modules\MediaLibrary\Catalog\Enums;
+enum Visibility: string { case Private='private'; case Restricted='restricted'; case Public='public'; }
+enum ItemKind: string { case Image='image'; case Video='video'; case Audio='audio'; case Document='document'; case Archive='archive'; case Other='other'; }
+enum AttachmentRole: string {
+    case Cover='cover'; case Social='social'; case Gallery='gallery'; case Thumbnail='thumbnail';
+    case Attachment='attachment'; case Hero='hero'; case Logo='logo'; case Favicon='favicon';
+}
+
+namespace Kurt\Modules\MediaLibrary\Storage\Enums;
+enum PendingUploadStatus: string { case Pending='pending'; case Completed='completed'; case Cancelled='cancelled'; case Expired='expired'; }
+
+namespace Kurt\Modules\MediaLibrary\Sharing\Enums;
+enum ShareAbility: string { case View='view'; case Download='download'; }
+enum AccessAction: string { case View='view'; case Download='download'; case Upload='upload'; case Replace='replace'; case Delete='delete'; }
+
+namespace Kurt\Modules\MediaLibrary\Access\Enums;
+enum Capability: string {
+    case View='view'; case Download='download'; case Manage='manage';
+    public function rank(): int { return match($this) { self::View => 1, self::Download => 2, self::Manage => 3 }; }
+}
+enum SubjectType: string { case User='user'; case Role='role'; case Everyone='everyone'; }
+```
+
+## 7. Spatie integration shape
+
+### 7.1 `MediaLibraryStorage` host model
+
+A tiny `HasMedia` model:
+
+```php
+namespace Kurt\Modules\MediaLibrary\Catalog\Models;
+
+use Spatie\MediaLibrary\HasMedia;
+use Spatie\MediaLibrary\InteractsWithMedia;
+
+class MediaLibraryStorage extends Model implements HasMedia
+{
+    use InteractsWithMedia;
+
+    protected $table = 'media_library_storage';
+    protected $fillable = ['item_uid'];
+
+    public function registerMediaCollections(): void
+    {
+        $this->addMediaCollection('mli')->singleFile();
+    }
+
+    public function registerMediaConversions(?Media $media = null): void
+    {
+        foreach ((array) config('media-library.conversions', []) as $name => $spec) {
+            $conversion = $this->addMediaConversion($name)
+                ->width((int) ($spec['width'] ?? 0))
+                ->height((int) ($spec['height'] ?? 0));
+            if (($spec['fit'] ?? 'fit') === 'crop') {
+                $conversion->fit('crop');
+            }
+        }
+    }
+}
+```
+
+### 7.2 Why this design
+
+- Isolates our spatie collection (`mli`) from any other `HasMedia` use the consumer has.
+- Each `MediaLibraryItem` has exactly one `MediaLibraryStorage` host owning one spatie Media file.
+- Polymorphic attachments link **to `MediaLibraryItem.id`**, not to the spatie Media. Replacing the file via `replaceWith()` swaps the spatie Media under a stable item id — every existing attachment continues to resolve.
+- Versioning is captured in `media_library_versions` (one row per replacement). The current `MediaLibraryStorage` always points at the latest spatie Media; old spatie Media rows can be retained (configurable retention) and pruned via `media-library:prune-versions`.
+
+### 7.3 Spatie collection naming
+
+The single collection `mli` per host. The host carries a unique `item_uid` UUID column so that conversion paths land under deterministic prefixes (`mli/{item_uid}/...`).
+
+## 8. Upload flow
+
+### 8.1 Server-proxy upload
+
+`MediaLibrary::upload(UploadedFile $file, MediaLibraryOwner $owner, ?Folder $folder = null, array $attributes = []): MediaLibraryItem`:
+
+1. Persist `MediaLibraryStorage` host with a fresh `item_uid`.
+2. Attach the spatie Media file to the `mli` collection on the host.
+3. Persist `MediaLibraryItem` with file metadata + owner + folder.
+4. Run post-processing pipeline (sync): dimensions, dominant_color, blurhash, palette. Optional async pipeline for EXIF / AI tagging / OCR when contracts are bound (dispatched as queued jobs).
+5. Increment denormalised `folder.item_count` and ancestor `descendant_count`.
+6. Dispatch `ItemUploaded(item)`.
+
+### 8.2 Presigned direct-to-S3
+
+`MediaLibrary::initiateUpload(MediaLibraryOwner $owner, array $filenameMeta): PendingUpload`:
+
+1. Validate mime_type + byte_size against `config('media-library.uploads.max_size_kb')` and allowed mimes.
+2. Generate `upload_id` (uuid).
+3. Create presigned PUT URL via `Storage::disk('s3')->temporaryUploadUrl(...)`.
+4. Persist `media_library_pending_uploads` row with status=Pending + expires_at = now + `config('media-library.uploads.presigned_ttl_seconds')`.
+5. Return PendingUpload row (containing `upload_id` + presigned URL + headers + key).
+
+Client uploads to S3 directly. On success, client calls:
+
+`MediaLibrary::completeUpload(string $uploadId): MediaLibraryItem`:
+
+1. Look up PendingUpload row; verify status Pending + not expired.
+2. Verify the object exists on the S3 disk + read final byte_size + mime_type.
+3. Persist `MediaLibraryStorage` host + attach the existing S3 object as the spatie Media file (using spatie's `addMediaFromDisk` or `addMediaFromUrl`).
+4. Persist `MediaLibraryItem` + run sync post-processing.
+5. Mark PendingUpload completed_at + status=Completed.
+
+`MediaLibrary::cancelUpload(string $uploadId)`: marks PendingUpload Cancelled.
+
+A scheduled `media-library:expire-pending-uploads` command marks Pending rows past expiry as Expired.
+
+### 8.3 Default tenancy
+
+When `owner` is omitted, default to the authed user resolved via the `MediaSubjectResolver` contract's `defaultOwner()` method. The DefaultSubjectResolver returns `auth()->user()` or throws `OwnerNotResolved` when unauthenticated.
+
+## 9. Replace flow (`MediaLibraryItem::replaceWith`)
+
+`MediaLibrary::replace(MediaLibraryItem $item, UploadedFile|PendingUpload $new, string $changelog): MediaLibraryItem` is the public entry point.
+
+Internally `ReplaceCoordinator`:
+
+1. Capture current spatie Media row id (will become the previous version reference).
+2. Persist `media_library_versions` row pointing at the current spatie Media id + filename + mime + byte_size + changelog.
+3. Attach the new file (server proxy) OR finalize the PendingUpload (S3 direct).
+4. Swap the `MediaLibraryStorage` host's spatie Media — delete the old spatie Media row only if `config('media-library.versions.hard_delete_old_files')` is true; otherwise leave it for the prune command.
+5. Recompute dimensions / dominant_color / blurhash / palette.
+6. Regenerate named conversions for the new file.
+7. Invalidate `media_library_variants` rows for this item (or queue regeneration).
+8. Dispatch `ItemReplaced(item, previousSpatieMediaId)`.
+
+The **item id stays the same**. All `media_library_attachments` rows continue to resolve.
+
+`media-library:prune-versions {item?}` deletes spatie Media rows older than `config('media-library.versions.keep_old', 10)` newest, never deleting the current.
+
+## 10. Conversions
+
+### 10.1 Named presets
+
+`config('media-library.conversions')`:
+
+```php
+return [
+    'thumb' => ['width' => 320, 'height' => 320, 'fit' => 'crop'],
+    'cover' => ['width' => 1200, 'height' => 630, 'fit' => 'crop'],
+    'social' => ['width' => 1600, 'height' => 900, 'fit' => 'crop'],
+];
+```
+
+`MediaLibraryItem::url(?string $conversion = null): string`:
+
+- `null` → original.
+- preset name → spatie conversion URL.
+- ad-hoc → see §10.2.
+
+When the conversion is `fit=crop` and item has non-default focal_x/y, `FocalPointCropper` applies a focal crop instead of a centered crop. Implemented by extending the conversion via spatie's `manipulations()->manualCrop(...)` calculated from focal point + target dimensions.
+
+### 10.2 Ad-hoc variants
+
+`MediaLibraryItem::variant(array $spec): MediaLibraryVariant`:
+
+```php
+$spec = ['width' => 600, 'height' => 400, 'fit' => 'fit', 'format' => 'webp', 'quality' => 80];
+```
+
+1. Canonicalize the spec into a deterministic `key` (e.g. `600x400-fit-webp-q80`).
+2. Look up `media_library_variants(item_id, key)` — if present, update `last_used_at` and return.
+3. Otherwise generate via `VariantGenerator` (uses Intervention). Persist a variant row pointing at the cached file on disk.
+4. Dispatch `VariantGenerated(variant)`.
+
+`media-library:prune-variants {item?}` removes variant rows + cache files where `last_used_at < now() - config('media-library.variants.unused_days')`.
+
+## 11. Linking to consumer models
+
+### 11.1 `HasMediaLibraryItems` trait
+
+```php
+trait HasMediaLibraryItems
+{
+    public function mediaItemAttachments(): MorphMany
+    {
+        return $this->morphMany(MediaLibraryAttachment::class, 'attachable');
+    }
+
+    public function mediaItems(?string $role = null): MorphToMany
+    {
+        $relation = $this->morphToMany(MediaLibraryItem::class, 'attachable', 'media_library_attachments', null, 'item_id')
+            ->withPivot(['role', 'position'])
+            ->withTimestamps()
+            ->orderBy('media_library_attachments.position');
+
+        if ($role !== null) {
+            $relation->wherePivot('role', $role);
+        }
+
+        return $relation;
+    }
+
+    public function attachMediaItem(MediaLibraryItem $item, string $role = 'attachment', ?int $position = null): MediaLibraryAttachment
+    {
+        $position ??= $this->mediaItemAttachments()->where('role', $role)->max('position') + 1;
+        return MediaLibraryAttachment::create([
+            'item_id' => $item->id,
+            'attachable_type' => $this->getMorphClass(),
+            'attachable_id' => $this->getKey(),
+            'role' => $role,
+            'position' => $position,
+        ]);
+    }
+
+    public function detachMediaItem(MediaLibraryItem $item, ?string $role = null): void
+    {
+        $q = $this->mediaItemAttachments()->where('item_id', $item->id);
+        if ($role !== null) $q->where('role', $role);
+        $q->delete();
+    }
+
+    public function coverItem(): ?MediaLibraryItem { return $this->mediaItems('cover')->first(); }
+    public function socialItem(): ?MediaLibraryItem { return $this->mediaItems('social')->first(); }
+}
+```
+
+### 11.2 Consumer-side stable identifier
+
+Consumer code references **`MediaLibraryItem::id`** (or the cover/social/gallery role). Never a `media_library_item_id` foreign-key column. Replacements keep the id stable, so existing references continue to work.
+
+## 12. Folder ACL (reuses ResourceLibrary pattern)
+
+### 12.1 `MediaSubjectResolver` contract
+
+```php
+interface MediaSubjectResolver
+{
+    /** @return array<int, Subject> */
+    public function subjects(?Authenticatable $user): array;
+
+    public function defaultOwner(?Authenticatable $user): MediaLibraryOwner;
+}
+```
+
+A single resolver class is bound in `config('media-library.subject_resolver')`. Default resolver returns `[Everyone, User($id)]` + treats authed user as the default owner.
+
+Consumers integrating with ResourceLibrary can ship a single shared resolver that satisfies both modules' subject contracts.
+
+### 12.2 `FolderPermissionResolver`
+
+Identical algorithm to ResourceLibrary §7.2:
+
+1. Walk ancestry from the folder upward.
+2. For the nearest ancestor with a matching ACL row, pick the highest capability across matching subjects.
+3. If no row matches, fall back to `Folder.visibility` (public → download for all; restricted → deny; private → owner only).
+
+### 12.3 `MediaLibraryAccess` cached check
+
+Per-request memoised wrapper. `MediaLibraryAccess::check(?Auth $u, Folder|MediaLibraryItem $target, Capability $needed): bool`. Items inherit their folder's permissions; orphan items (folder_id null) are owner-only.
+
+## 13. Sharing
+
+### 13.1 Share links
+
+`MediaLibrary::shareItem(MediaLibraryItem $item, int $expiresInSeconds, array $abilities = ['view'], ?string $invitee = null): string` and `MediaLibrary::shareFolder(Folder $folder, …)`:
+
+1. Generate url-safe `token` (32 chars).
+2. Persist `media_library_share_links` row.
+3. Return full URL using the route registered when `config('media-library.routes.share_enabled')` is true.
+
+Route: `/media-library/share/{token}`. Controller:
+
+1. Look up token; reject if missing / revoked / past expiry.
+2. Verify requested ability is in stored abilities.
+3. Increment `access_count`, set `last_accessed_at`, persist `media_library_access_log` row.
+4. For items: stream the file (`view` → display; `download` → attachment header). For folders: render a minimal JSON manifest of contained items (consumer wires UI on top).
+
+`MediaLibrary::revokeShare(string $token)`. `MediaLibraryItem::activeShares(): Collection`.
+
+### 13.2 Scheduled expiry
+
+`media-library:expire-shares` marks share links past `expires_at` as effectively expired (no row deletion, just check on access). Optional GDPR-style hard-delete is `media-library:prune-shares` retaining expired rows for N days.
+
+## 14. Search + tagging
+
+### 14.1 Default scopes
+
+```php
+MediaLibraryItem::query()
+    ->byOwner($owner)                 // matches owner_type + owner_id
+    ->byFolder($folder, recursive: true)
+    ->byTag($tagOrSlug)
+    ->byMimeType('image/*')           // wildcard support
+    ->byDateRange($from, $to)
+    ->search('autumn beach');          // LIKE on title+alt+caption+description across translations
+```
+
+### 14.2 Scout adapter (optional)
+
+```php
+namespace Kurt\Modules\MediaLibrary\Search\Contracts;
+
+interface ScoutAdapter
+{
+    public function index(MediaLibraryItem $item): void;
+    public function unindex(MediaLibraryItem $item): void;
+    /** @return Collection<int, MediaLibraryItem> */
+    public function search(string $query, array $filters = [], int $limit = 50): Collection;
+}
+```
+
+Consumer binds a `LaravelScoutAdapter` (a small wrapper around `laravel/scout`) if they want Scout-backed search. When bound, `MediaLibraryItem::search()` scope delegates to the adapter; otherwise falls back to LIKE.
+
+### 14.3 Tags
+
+`MediaLibrary::tag(MediaLibraryItem $item, string|MediaLibraryTag $tag): MediaLibraryTag` — find-or-create tag (owner-scoped), attach. `MediaLibrary::untag($item, $tag)`. Tag colors + position support a faceted filter UI.
+
+### 14.4 Saved searches
+
+`MediaLibrary::saveSearch(Model $user, string $name, array $filters): MediaLibrarySavedSearch`. Filters is an arbitrary JSON blob the consumer chose for their UI. Module never interprets fields beyond persistence.
+
+## 15. Pluggable contracts
+
+```
+Kurt\Modules\MediaLibrary\Storage\Contracts\
+  ExifExtractor       -- extract(string $path): array
+  OcrExtractor        -- extract(string $path): string
+  AiTagger            -- tag(string $path): array<int, string>
+  BlurhashGenerator   -- generate(string $path): string
+  PaletteExtractor    -- extract(string $path): array{dominant: string, palette: array<int, string>}
+
+Kurt\Modules\MediaLibrary\Search\Contracts\
+  ScoutAdapter
+
+Kurt\Modules\MediaLibrary\Access\Contracts\
+  MediaSubjectResolver
+```
+
+Defaults shipped: `DefaultExifExtractor` (PHP `exif_read_data` for JPEG/TIFF), `InterventionBlurhashGenerator`, `InterventionPaletteExtractor`, `DefaultSubjectResolver` (Everyone + User). No defaults for OCR / AI / Scout — consumer wires.
+
+Bindings via `config('media-library.contracts.*')` FQCN map.
+
+## 16. Top-level facade
+
+```php
+namespace Kurt\Modules\MediaLibrary\Support;
+
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\UploadedFile;
+use Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibraryFolder;
+use Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibraryItem;
+use Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibrarySavedSearch;
+use Kurt\Modules\MediaLibrary\Contracts\MediaLibraryOwner;
+use Kurt\Modules\MediaLibrary\Storage\Models\MediaLibraryPendingUpload;
+
+final class MediaLibrary
+{
+    // Uploads
+    public function upload(UploadedFile $file, ?MediaLibraryOwner $owner = null, ?MediaLibraryFolder $folder = null, array $attributes = []): MediaLibraryItem;
+    public function initiateUpload(?MediaLibraryOwner $owner, array $filenameMeta): MediaLibraryPendingUpload;
+    public function completeUpload(string $uploadId): MediaLibraryItem;
+    public function cancelUpload(string $uploadId): void;
+
+    // Replace
+    public function replace(MediaLibraryItem $item, UploadedFile|MediaLibraryPendingUpload $new, string $changelog): MediaLibraryItem;
+
+    // Folders
+    public function createFolder(MediaLibraryOwner $owner, string $name, ?MediaLibraryFolder $parent = null): MediaLibraryFolder;
+    public function moveFolderTo(MediaLibraryFolder $folder, ?MediaLibraryFolder $newParent): MediaLibraryFolder;
+    public function moveItems(array $itemIds, ?MediaLibraryFolder $newFolder): int;
+
+    // Trash + restore
+    public function trash(MediaLibraryItem|MediaLibraryFolder $target): void;
+    public function restore(MediaLibraryItem|MediaLibraryFolder $target): void;
+
+    // Sharing
+    public function shareItem(MediaLibraryItem $item, int $expiresInSeconds, array $abilities = ['view'], ?string $invitee = null): string;
+    public function shareFolder(MediaLibraryFolder $folder, int $expiresInSeconds, array $abilities = ['view'], ?string $invitee = null): string;
+    public function revokeShare(string $token): void;
+
+    // Tagging
+    public function tag(MediaLibraryItem $item, string|\Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibraryTag $tag): \Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibraryTag;
+    public function untag(MediaLibraryItem $item, string|\Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibraryTag $tag): void;
+
+    // Saved searches
+    public function saveSearch(Model $user, string $name, array $filters): MediaLibrarySavedSearch;
+    public function runSearch(MediaLibrarySavedSearch $search): Collection;
+
+    // Maintenance
+    public function pruneVersions(MediaLibraryItem $item, int $keepNewest = 10): int;
+    public function pruneVariants(MediaLibraryItem $item, int $unusedDays = 30): int;
+    public function rebuildPaths(MediaLibraryOwner $owner): int;
+    public function recountCounters(MediaLibraryOwner $owner): int;
+}
+```
+
+## 17. Person-side contracts + traits
+
+```
+Kurt\Modules\MediaLibrary\Contracts\MediaLibraryOwner    -- interface getKey + getMorphClass
+Kurt\Modules\MediaLibrary\Concerns\IsMediaLibraryOwner   -- adds mediaLibraryItems() / mediaLibraryFolders() helpers
+Kurt\Modules\MediaLibrary\Concerns\HasMediaLibraryItems  -- consumer-model trait (see §11.1)
+```
+
+The `MediaLibraryOwner` interface is implemented by User/Team/Organization classes via `IsMediaLibraryOwner` trait. Polymorphic `owner_type + owner_id` columns store the relation.
+
+## 18. Auth / policies
+
+- `MediaLibraryItemPolicy` — view/download/manage delegate to `MediaLibraryAccess::check`.
+- `MediaLibraryFolderPolicy` — same.
+- `ShareLinkPolicy` — create requires `manage` on the target; revoke requires creator or manage.
+- `SavedSearchPolicy` — user owns their saved searches.
+- Global gate `canAdminMediaLibrary` bypasses for staff.
+
+## 19. Config (`config/media-library.php`)
+
+```php
+return [
+    'subject_resolver' => Kurt\Modules\MediaLibrary\Access\Support\DefaultSubjectResolver::class,
+
+    'contracts' => [
+        'exif' => Kurt\Modules\MediaLibrary\Storage\Extractors\DefaultExifExtractor::class,
+        'blurhash' => Kurt\Modules\MediaLibrary\Storage\Extractors\InterventionBlurhashGenerator::class,
+        'palette' => Kurt\Modules\MediaLibrary\Storage\Extractors\InterventionPaletteExtractor::class,
+        'ocr' => null,
+        'ai_tagger' => null,
+        'scout' => null,
+    ],
+
+    'uploads' => [
+        'disk' => env('MEDIA_LIBRARY_DISK', 'public'),
+        'max_size_kb' => 100_000,
+        'allowed_mimes' => ['image/*', 'video/*', 'audio/*', 'application/pdf', 'application/zip'],
+        'presigned_ttl_seconds' => 900,
+        'expire_pending_after_seconds' => 3600,
+    ],
+
+    'conversions' => [
+        'thumb' => ['width' => 320, 'height' => 320, 'fit' => 'crop'],
+        'cover' => ['width' => 1200, 'height' => 630, 'fit' => 'crop'],
+        'social' => ['width' => 1600, 'height' => 900, 'fit' => 'crop'],
+    ],
+
+    'variants' => [
+        'unused_days' => 30,
+        'max_per_item' => 100,
+    ],
+
+    'versions' => [
+        'keep_old' => 10,
+        'hard_delete_old_files' => false,
+    ],
+
+    'routes' => [
+        'share_enabled' => true,
+        'share_prefix' => 'media-library/share',
+    ],
+
+    'extractors' => [
+        'sync' => ['dimensions', 'palette', 'blurhash'],   // run in request
+        'async' => ['exif', 'ai_tagger', 'ocr'],            // dispatched as jobs
+    ],
+
+    'access_log' => [
+        'enabled' => true,
+        'on_view' => true,
+        'on_download' => true,
+    ],
+
+    'audit' => [
+        'enabled' => true,
+    ],
+
+    'models' => [
+        'item' => Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibraryItem::class,
+        'folder' => Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibraryFolder::class,
+        'tag' => Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibraryTag::class,
+        'attachment' => Kurt\Modules\MediaLibrary\Catalog\Models\MediaLibraryAttachment::class,
+        'share_link' => Kurt\Modules\MediaLibrary\Sharing\Models\ShareLink::class,
+    ],
+];
+```
+
+## 20. Console commands
+
+- `media-library:prune-versions {item?}` — drop versions older than `keep_old`.
+- `media-library:prune-variants {item?}` — drop unused variants past `unused_days`.
+- `media-library:rebuild-paths {owner?}` — recompute folder `path` + `depth`.
+- `media-library:recount {owner?}` — rebuild `item_count` + `descendant_count`.
+- `media-library:expire-shares` — runs hourly. Closes expired share links.
+- `media-library:prune-shares` — hard-delete expired share links beyond retention.
+- `media-library:expire-pending-uploads` — runs every 5 minutes. Marks expired pending uploads.
+- `media-library:reextract {item}` — re-run EXIF/blurhash/palette/AI tagger for one item.
+- `media-library:reindex {owner?}` — push items to bound ScoutAdapter.
+- `media-library:demo` — seed sample folders + items.
+
+## 21. Optional Laravel Notifications
+
+Under `src/Notifications/` (only registered when `config('media-library.notifications.enabled')`):
+
+- `ShareLinkCreated` (to invitee_email when set)
+- `ShareLinkAccessed` (to share creator on first access)
+- `ItemReplaced` (to subscribers of the item via consumer-supplied mechanism)
+- `LargeUploadCompleted` (to uploader)
+
+Default Blade templates under `resources/views/notifications/*.blade.php`, publishable for branding.
+
+## 22. Domain events
+
+- Catalog: `FolderCreated`, `FolderUpdated`, `FolderMoved`, `FolderDeleted`, `FolderRestored`, `FolderPermissionChanged`.
+- Items: `ItemUploaded`, `ItemUpdated`, `ItemReplaced(item, previousSpatieMediaId)`, `ItemAttached`, `ItemDetached`, `ItemTagged`, `ItemUntagged`, `ItemTrashed`, `ItemRestored`, `ItemDeleted`, `ItemViewed`, `ItemDownloaded`.
+- Storage: `UploadInitiated`, `UploadCompleted`, `UploadCancelled`, `UploadExpired`, `VariantGenerated`, `VersionPruned`, `BlurhashComputed`, `PaletteComputed`, `ExifExtracted`, `AiTagsAssigned`, `TextExtracted`.
+- Sharing: `ShareLinkCreated`, `ShareLinkAccessed`, `ShareLinkRevoked`, `ShareLinkExpired`.
+- Audit: every state-changing facade method writes a row to `media_library_access_log` with the appropriate `AccessAction` (upload | replace | delete) plus actor/ip/user_agent. Cross-module audit aggregation is a v1.1 follow-up (see §24).
+
+## 23. Filament admin (v1.1)
+
+Resources planned:
+
+- `MediaLibraryItemResource` — WordPress-grid view, file edit modal (alt/caption/description/focal/tags), version history, attachment manager.
+- `MediaLibraryFolderResource` — tree view + ACL relation manager.
+- `MediaLibraryTagResource`.
+- `ShareLinkResource` — read-only access log + revoke action.
+
+v1.0 ships **headless**. v1.1 adds the resources. Resource bodies live under `src/Filament/V{3,4,5}/Resources/…`.
+
+## 24. Audit log
+
+For v1.0, the access log (`media_library_access_log`) covers view/download/upload/replace/delete actions. A richer cross-module audit log was introduced in Events as `events_audit_log`. v1.1 may promote that to a shared `ozankurt/laravel-modules-audit` package — out of scope for v1.0 of Media Library.
+
+## 25. Testing matrix
+
+### Unit
+- All enums (cases + values).
+- `FocalPointCropper` math (focal at corners + center).
+- `ShareLinkSigner::generate + verify` round-trip.
+- `ItemSlugger` owner-scoped uniqueness.
+- Variant key canonicalization.
+
+### Feature (Pest + Testbench)
+- Server-proxy upload happy path → MediaLibraryItem persisted + spatie file present + dimensions extracted.
+- Replace flow: stable item id + version row created + attachments preserved.
+- Folder moveTo: rewrites descendant paths in one query.
+- Folder ACL matrix (cascade × visibility fallback × subject mismatch × inheritance).
+- Polymorphic attachments: attach + detach + multi-role + position ordering.
+- Tag attach/detach + owner-scoped uniqueness.
+- Share link: creation + view + download + access log + revoke + expiry.
+- Pending upload: initiate + complete + cancel + expire command.
+- Conversion presets registered on the host model.
+- Ad-hoc variant generation + cache hit on second call.
+- Default search scopes.
+- Scout adapter dispatch when bound.
+- Notifications dispatched when enabled in config.
+- Access log writes per `on_view` / `on_download` config knobs.
+- GDPR-style trash + restore preserves attachments through soft-delete.
+
+Coverage target: **70%** lines (v1.0 has heavy lifecycle code).
+
+## 26. Repository setup
+
+Create empty GitHub repo `https://github.com/OzanKurt/KurtModules-MediaLibrary`. Initial commit with `SECURITY.md` + `LICENSE.md`. Branch `v1.0`. Implementation plan references this spec.
+
+## 27. Definition of done (v1.0)
+
+- [ ] Pint + PHPStan level 8 + Pest (≥ 70% line coverage) all green.
+- [ ] CI matrix green on Laravel 12.
+- [ ] Upload (server-proxy AND presigned) happy paths covered.
+- [ ] Replace flow proves stable item id + attachment preservation.
+- [ ] Conversion presets + ad-hoc variants + focal-point cropping all tested.
+- [ ] Folder ACL matrix exhaustive.
+- [ ] Share-link end-to-end with access log.
+- [ ] All commands behave per spec §20.
+- [ ] README + CHANGELOG + UPGRADE-1.0 + GDPR notes in place.
+- [ ] Tagged `v1.0.0` after merge to master.
+
+## 28. Open follow-ups (not in v1.0)
+
+- Filament v1.1 admin resources (planned).
+- Promote cross-module audit log to a shared package (`ozankurt/laravel-modules-audit`).
+- Multi-disk policies (auto-route per mime / size to S3 vs local).
+- Image optimisation contract (sharp / cwebp / etc.).
+- Bulk upload UX endpoints (chunked uploads).
+- CDN signed-URL plugin for short-TTL cache.
+- Video thumbnail / poster frame extraction via FFmpeg contract.
+
+## 29. References
+
+- [Umbrella v2 design](./2026-05-28-kurtmodules-v2-design.md)
+- [Events v1 spec](./2026-05-29-kurtmodules-events-v1-spec.md) — refund / payout / facade conventions
+- [Library rename spec](./2026-05-30-kurtmodules-resource-library-rename-spec.md)
+- `spatie/laravel-medialibrary` v11 documentation for collection + conversion APIs.

--- a/docs/superpowers/specs/2026-05-30-kurtmodules-resource-library-rename-spec.md
+++ b/docs/superpowers/specs/2026-05-30-kurtmodules-resource-library-rename-spec.md
@@ -1,0 +1,133 @@
+# `ozankurt/laravel-modules-library` → `ozankurt/laravel-modules-resource-library` v3.0 — Rename Spec
+
+**Repo:** `KurtModules-Library`
+**Date:** 2026-05-30
+**Status:** Draft → user review pending
+**Family:** [KurtModules v2 umbrella](./2026-05-28-kurtmodules-v2-design.md)
+
+---
+
+## 1. Purpose
+
+The existing `ozankurt/laravel-modules-library` v2 is a **SaaS resource library** (nested folders containing videos/files/documents/links with per-folder permissions). The new `ozankurt/laravel-modules-media-library` v1 is a **WordPress-style media bucket** for image/video/audio assets.
+
+To prevent confusion between the two, rename the existing Library module to **Resource Library** in a v3 release. The media library keeps the clean name.
+
+## 2. Scope
+
+### 2.1 What changes
+
+| | v2 | v3 |
+|---|---|---|
+| Composer name | `ozankurt/laravel-modules-library` | `ozankurt/laravel-modules-resource-library` |
+| PHP namespace | `Kurt\Modules\Library\` | `Kurt\Modules\ResourceLibrary\` |
+| Service provider | `LibraryServiceProvider` | `ResourceLibraryServiceProvider` |
+| Config key | `library` | `resource-library` |
+| Facade alias | `Library` | `ResourceLibrary` |
+| Console command prefix | `library:*` | `resource-library:*` |
+| Table prefix | `library_*` | `resource_library_*` |
+| README + docs | "Library" | "Resource Library" |
+
+### 2.2 What stays the same
+
+- Repo name on GitHub stays `KurtModules-Library` (cheap to leave alone).
+- Schema shape (column names, relations, indexes).
+- Public API surface (model methods, scopes, policy gates).
+- Filament resource class names (planned for v2.1).
+- Domain event class names — but they move namespace.
+- spatie/laravel-translatable + spatie/laravel-medialibrary + Sluggable deps unchanged.
+
+## 3. Migration strategy
+
+### 3.1 Database
+
+Rename all `library_*` tables to `resource_library_*` via a single migration shipped in v3:
+
+```
+library_folders                 -> resource_library_folders
+library_items                   -> resource_library_items
+library_item_versions           -> resource_library_item_versions
+library_tags                    -> resource_library_tags
+library_item_tag                -> resource_library_item_tag
+library_folder_permissions      -> resource_library_folder_permissions
+library_access_log              -> resource_library_access_log
+```
+
+Migration uses `Schema::rename(...)` per table. Indexes and foreign keys persist across the rename.
+
+### 3.2 Composer
+
+Consumers update `composer.json`:
+
+```diff
+-"ozankurt/laravel-modules-library": "^2.0"
++"ozankurt/laravel-modules-resource-library": "^3.0"
+```
+
+The old package name is **abandoned** on Packagist (once published) with a pointer to the new name. Until Packagist publishing happens, the existing VCS repository entry in downstream modules continues to work (URL unchanged).
+
+### 3.3 Code
+
+Find-and-replace across consumer code:
+
+| Find | Replace |
+|---|---|
+| `Kurt\Modules\Library\` | `Kurt\Modules\ResourceLibrary\` |
+| `Kurt\\Modules\\Library\\` | `Kurt\\Modules\\ResourceLibrary\\` |
+| `config('library.` | `config('resource-library.` |
+| `'library:` (artisan signatures) | `'resource-library:` |
+| `LibraryServiceProvider` | `ResourceLibraryServiceProvider` |
+| `library/*` view names (if any) | `resource-library/*` |
+
+A `resource-library:upgrade-from-library` artisan command optionally automates step 3.3 inside a consumer app — scans for the old namespace usage in `app/`, prints a diff, applies on confirmation.
+
+### 3.4 Branch + tag plan
+
+- Branch `v3.0` off `master`.
+- Rename refactor on `v3.0`.
+- Shipping migration `2026_05_30_NNNNNN_rename_library_to_resource_library.php`.
+- Updated README + CHANGELOG + UPGRADE-3.0.md describing the rename + steps for consumers.
+- Tag `v3.0.0` after merge.
+- Optional: also tag a `v2.0.1` on the v2 line that does nothing but warn (e.g. via composer scripts post-install message) about the upcoming rename.
+
+## 4. Files to touch
+
+Across the repo:
+
+- `composer.json` — `name`, `description`, `keywords`, `autoload.psr-4`, `autoload-dev.psr-4`, `extra.laravel.providers`.
+- `config/library.php` → `config/resource-library.php` (rename file + replace internal references to model FQCNs).
+- `src/` — rename `Kurt\Modules\Library\` namespace to `Kurt\Modules\ResourceLibrary\` via mass `sed` + composer autoload regenerate.
+- `src/Providers/LibraryServiceProvider.php` → `ResourceLibraryServiceProvider.php`.
+- `src/Facades/Library.php` → `ResourceLibrary.php`.
+- `src/Console/Commands/*` — update signatures from `library:foo` to `resource-library:foo`.
+- All migrations: rename inside `Schema::create(...)` calls in **new follow-up migration**; existing migrations stay untouched for installs already on v2.
+- All factories: namespace rename.
+- All tests: namespace rename + table assertion fixes.
+- `tests/TestCase.php` — provider FQCN.
+- `README.md`, `CHANGELOG.md`, `UPGRADE-3.0.md` — full rewrite.
+- `.github/workflows/tests.yml` — workflow name + comment refresh.
+- `LICENSE.md` — author line unchanged.
+
+## 5. Definition of done
+
+- [ ] All tables renamed via a v3 migration.
+- [ ] Namespace + composer name + provider class updated everywhere.
+- [ ] All previously-passing tests still pass after refactor.
+- [ ] Pint + PHPStan clean.
+- [ ] `UPGRADE-3.0.md` provides a step-by-step for consumer migration.
+- [ ] Tagged `v3.0.0` on `master`.
+- [ ] GitHub release + CHANGELOG entry.
+- [ ] Downstream modules' VCS repo references continue to work (URL unchanged).
+- [ ] Old v2 line marked deprecated in README + Packagist (when published) → "Use ozankurt/laravel-modules-resource-library instead."
+
+## 6. Non-goals
+
+- No functional feature changes.
+- No schema changes beyond table renames.
+- No Filament resource changes (still deferred to v3.1 — was v2.1).
+- No tooling upgrade (still Laravel 12 + PHP 8.4 + same dev deps).
+
+## 7. References
+
+- [Media Library v1 spec](./2026-05-30-kurtmodules-media-library-v1-spec.md) — the reason for the rename.
+- [Umbrella v2 design](./2026-05-28-kurtmodules-v2-design.md).

--- a/src/Providers/BlogServiceProvider.php
+++ b/src/Providers/BlogServiceProvider.php
@@ -37,13 +37,7 @@ final class BlogServiceProvider extends PackageServiceProvider
             ->name('laravel-modules-blog')
             ->hasConfigFile('blog')
             ->hasTranslations()
-            ->hasMigrations([
-                'create_blog_categories_table',
-                'create_blog_tags_table',
-                'create_blog_posts_table',
-                'create_blog_post_tag_table',
-                'create_blog_comments_table',
-            ])
+            ->discoversMigrations()
             ->hasCommands([
                 PublishDuePostsCommand::class,
                 UpgradeTranslationsCommand::class,

--- a/tests/Feature/MigrationPublishingTest.php
+++ b/tests/Feature/MigrationPublishingTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\ServiceProvider;
+use Kurt\Modules\Blog\Providers\BlogServiceProvider;
+
+it('registers publishable migration sources that point at real files', function () {
+    $paths = ServiceProvider::pathsToPublish(BlogServiceProvider::class, 'modules-blog-migrations');
+
+    expect($paths)->not->toBeEmpty();
+
+    foreach (array_keys($paths) as $source) {
+        expect(is_file($source))->toBeTrue("publishable migration source does not exist on disk: {$source}");
+    }
+});
+
+it('publishes one entry per migration file in the package', function () {
+    $paths = ServiceProvider::pathsToPublish(BlogServiceProvider::class, 'modules-blog-migrations');
+    $packageMigrations = glob(__DIR__.'/../../database/migrations/*.php');
+
+    expect(count($paths))->toBe(count($packageMigrations));
+});


### PR DESCRIPTION
Switches BlogServiceProvider from bare hasMigrations() list to discoversMigrations() so vendor:publish actually publishes the timestamp-prefixed migration files. Adds a regression test asserting every publishable source path is a real file.