### PR TITLE
feat: Filament v3/v4/v5 admin resources (Blog pilot, v2.1.0)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -16,15 +16,14 @@ jobs:
             matrix:
                 php: ['8.4']
                 laravel: ['12.*']
+                filament: ['3.*', '4.*', '5.*']
                 include:
                     - laravel: 12.*
                       testbench: 10.*
                 # Laravel 13 will be added once pestphp/pest-plugin-laravel
                 # publishes a release supporting laravel/framework ^13.0.
-                # Filament axis is pending v2.1 — admin resources are not
-                # shipped in v2.0 (module is headless).
 
-        name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }}
+        name: PHP ${{ matrix.php }} - Laravel ${{ matrix.laravel }} - Filament ${{ matrix.filament }}
 
         steps:
             - uses: actions/checkout@v4
@@ -40,15 +39,17 @@ jobs:
               uses: actions/cache@v4
               with:
                   path: ~/.composer/cache
-                  key: composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ hashFiles('composer.json') }}
+                  key: composer-${{ matrix.php }}-${{ matrix.laravel }}-${{ matrix.filament }}-${{ hashFiles('composer.json') }}
 
-            - name: Require Laravel ${{ matrix.laravel }}
+            - name: Require Laravel ${{ matrix.laravel }} + Filament ${{ matrix.filament }}
               run: |
                   composer require --no-update --no-interaction \
                       "illuminate/contracts:${{ matrix.laravel }}" \
                       "illuminate/database:${{ matrix.laravel }}" \
                       "illuminate/support:${{ matrix.laravel }}" \
-                      "orchestra/testbench:${{ matrix.testbench }}"
+                      "orchestra/testbench:${{ matrix.testbench }}" \
+                      "filament/filament:${{ matrix.filament }}" \
+                      "filament/spatie-laravel-media-library-plugin:${{ matrix.filament }}"
 
             - name: Install
               run: composer update --prefer-stable --prefer-dist --no-interaction
@@ -56,8 +57,10 @@ jobs:
             - name: Pint
               run: vendor/bin/pint --test
 
-            - name: PHPStan
-              run: vendor/bin/phpstan analyse --memory-limit=2G
+            - name: PHPStan (Filament ${{ matrix.filament }})
+              run: |
+                  MAJOR=$(echo "${{ matrix.filament }}" | cut -d. -f1)
+                  vendor/bin/phpstan analyse -c "phpstan-filament-v${MAJOR}.neon" --memory-limit=2G
 
             - name: Pest
               run: vendor/bin/pest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+## [2.1.0] - 2026-05-30
+
+### Added
+- Filament admin resources for **v3, v4, and v5** in parallel: `PostResource`, `CategoryResource`, `TagResource`, `CommentResource` under `src/Filament/V{3,4,5}`.
+- Version-dispatching `Kurt\Modules\Blog\Filament\BlogPlugin` facade — register `->plugin(BlogPlugin::make())` on your panel and the matching V{n} resource set is resolved from the installed Filament major via Core's `FilamentVersion`.
+- Post form with per-locale (en/tr) translatable title/excerpt/body and SEO meta, status/type enum selects, conditional `scheduled_for` (status=scheduled) and `video_url` (type=video) fields, category + tags relationship selects, and a `SpatieMediaLibraryFileUpload` cover; Comment moderation queue with approve/reject row + bulk actions.
+- `filament/spatie-laravel-media-library-plugin` (`^3.0 || ^4.0 || ^5.0`) added to `require-dev` for the Post cover upload.
+- Per-Filament-version PHPStan configs (`phpstan-filament-v{3,4,5}.neon`); the base `phpstan.neon` excludes the three version dirs and the dispatching facade.
+- CI matrix gains a Filament axis (`3.*`, `4.*`, `5.*`) with a per-major PHPStan step.
+
 ## [2.0.1] - 2026-05-30
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -32,9 +32,50 @@ php artisan migrate
 - Console commands: `blog:publish-due`, `blog:upgrade-translations`, `blog:demo`.
 - Domain events: `PostCreated`, `PostUpdated`, `PostPublished`, `PostArchived`, `CommentCreated`, `CommentApproved`, `CommentRejected`, ...
 
-## Filament
+## Filament admin
 
-Filament v3/v4/v5 admin resources are planned for v2.1. The package is headless in v2.0.
+The package ships parallel admin resource sets for Filament **v3, v4, and v5** —
+`PostResource`, `CategoryResource`, `TagResource`, and `CommentResource`. The
+correct set is chosen at runtime from the installed Filament major, so you
+register a single version-dispatching plugin on your panel:
+
+```php
+use Filament\Panel;
+use Kurt\Modules\Blog\Filament\BlogPlugin;
+
+public function panel(Panel $panel): Panel
+{
+    return $panel
+        // ...
+        ->plugin(BlogPlugin::make());
+}
+```
+
+`BlogPlugin::make()` resolves to the matching `V3`/`V4`/`V5` plugin via
+`Kurt\Modules\Core\Support\FilamentVersion`. Install whichever Filament major
+your app uses — the resources require nothing beyond what the module already
+depends on:
+
+```bash
+# whichever your app runs
+composer require filament/filament:"^3.0|^4.0|^5.0"
+composer require filament/spatie-laravel-media-library-plugin:"^3.0|^4.0|^5.0"
+```
+
+What the resources give you:
+
+- **Posts** — per-locale (en/tr) translatable title/excerpt/body and SEO meta;
+  status and type enum selects; a `scheduled_for` picker shown when the status
+  is *Scheduled* and a `video_url` field shown when the type is *Video*;
+  category and tag relationship selects; a Spatie media-library cover upload;
+  a table with status/type filters, badges, author, category, publish date and
+  view count.
+- **Categories** — translatable name/description, parent (tree) select, slug
+  read-only on edit, post counts.
+- **Tags** — translatable name/description with a colour picker and a colour
+  swatch column.
+- **Comments** — a moderation queue defaulting to pending, with approve/reject
+  row actions and approve/reject/delete bulk actions.
 
 ## License
 

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
   },
   "require-dev": {
     "filament/filament": "^3.0 || ^4.0 || ^5.0",
+    "filament/spatie-laravel-media-library-plugin": "^3.0 || ^4.0 || ^5.0",
     "larastan/larastan": "^3.0",
     "laravel/pint": "^1.18",
     "league/commonmark": "^2.5",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "44c4642fdb354e80763508abc4b2da6e",
+    "content-hash": "7a8bd41153127818554989d7aaf8955c",
     "packages": [
         {
             "name": "brick/math",
@@ -1077,16 +1077,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.10.3",
+            "version": "2.10.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7c1472269227dc6f18930bd903d7a88fe6c52130"
+                "reference": "d2a1a094e396da8957e797489fddaf860c340cfc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7c1472269227dc6f18930bd903d7a88fe6c52130",
-                "reference": "7c1472269227dc6f18930bd903d7a88fe6c52130",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/d2a1a094e396da8957e797489fddaf860c340cfc",
+                "reference": "d2a1a094e396da8957e797489fddaf860c340cfc",
                 "shasum": ""
             },
             "require": {
@@ -1174,7 +1174,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.10.3"
+                "source": "https://github.com/guzzle/psr7/tree/2.10.4"
             },
             "funding": [
                 {
@@ -1190,7 +1190,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-27T11:48:20+00:00"
+            "time": "2026-05-29T12:59:07+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
@@ -3927,20 +3927,20 @@
         },
         {
             "name": "symfony/clock",
-            "version": "v8.0.8",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "b55a638b189a6faa875e0ccdb00908fb87af95b3"
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/b55a638b189a6faa875e0ccdb00908fb87af95b3",
-                "reference": "b55a638b189a6faa875e0ccdb00908fb87af95b3",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "psr/clock": "^1.0"
             },
             "provide": {
@@ -3980,7 +3980,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v8.0.8"
+                "source": "https://github.com/symfony/clock/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4000,7 +4000,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-30T15:14:47+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/console",
@@ -4102,20 +4102,20 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v8.0.9",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "3665cfade90565430909b906394c73c8739e57d0"
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/3665cfade90565430909b906394c73c8739e57d0",
-                "reference": "3665cfade90565430909b906394c73c8739e57d0",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/dc0e2be45c9b5588c82414f02ac574b4b986abcd",
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4"
+                "php": ">=8.4.1"
             },
             "type": "library",
             "autoload": {
@@ -4147,7 +4147,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v8.0.9"
+                "source": "https://github.com/symfony/css-selector/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4167,7 +4167,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:51:42+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4324,20 +4324,21 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.0.9",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f"
+                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0c3c1a17604c4dbbec4b93fe162c538482096e1f",
-                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/f249ae3f680958b6f1f9dd76e5747cf0695b4102",
+                "reference": "f249ae3f680958b6f1f9dd76e5747cf0695b4102",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
@@ -4385,7 +4386,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.9"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4405,7 +4406,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:51:42+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -5997,20 +5998,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.0.13",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "f2e3e4d33579350d1b12001ef2872f86b27ed3dc"
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/f2e3e4d33579350d1b12001ef2872f86b27ed3dc",
-                "reference": "f2e3e4d33579350d1b12001ef2872f86b27ed3dc",
+                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-ctype": "^1.8",
                 "symfony/polyfill-intl-grapheme": "^1.33",
                 "symfony/polyfill-intl-normalizer": "^1.0",
@@ -6063,7 +6064,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.0.13"
+                "source": "https://github.com/symfony/string/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -6083,24 +6084,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-23T18:05:53+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v8.0.10",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "f63e9342e12646a57c91ef8a366a4f9d8e557b67"
+                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/f63e9342e12646a57c91ef8a366a4f9d8e557b67",
-                "reference": "f63e9342e12646a57c91ef8a366a4f9d8e557b67",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/b2bd012ca28c4acae830ee1206a5b6e35dd99693",
+                "reference": "b2bd012ca28c4acae830ee1206a5b6e35dd99693",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4",
+                "php": ">=8.4.1",
                 "symfony/polyfill-mbstring": "^1.0",
                 "symfony/translation-contracts": "^3.6.1"
             },
@@ -6156,7 +6157,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.0.10"
+                "source": "https://github.com/symfony/translation/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -6176,7 +6177,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-06T11:30:54+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -7661,6 +7662,43 @@
             "time": "2026-05-27T16:16:01+00:00"
         },
         {
+            "name": "filament/spatie-laravel-media-library-plugin",
+            "version": "v5.6.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/filamentphp/spatie-laravel-media-library-plugin.git",
+                "reference": "085dda340dd99dd350d9f8fd77015cd420d8b2d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/filamentphp/spatie-laravel-media-library-plugin/zipball/085dda340dd99dd350d9f8fd77015cd420d8b2d2",
+                "reference": "085dda340dd99dd350d9f8fd77015cd420d8b2d2",
+                "shasum": ""
+            },
+            "require": {
+                "filament/support": "self.version",
+                "php": "^8.2",
+                "spatie/laravel-medialibrary": "^11.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Filament\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Filament support for `spatie/laravel-medialibrary`.",
+            "homepage": "https://github.com/filamentphp/filament",
+            "support": {
+                "issues": "https://github.com/filamentphp/filament/issues",
+                "source": "https://github.com/filamentphp/filament"
+            },
+            "time": "2026-05-22T07:42:50+00:00"
+        },
+        {
             "name": "filament/support",
             "version": "v5.6.6",
             "source": {
@@ -8033,16 +8071,16 @@
         },
         {
             "name": "kirschbaum-development/eloquent-power-joins",
-            "version": "4.3.1",
+            "version": "4.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/kirschbaum-development/eloquent-power-joins.git",
-                "reference": "3f77b096c1e8b5aa1fc40d7080e55e795f3430ae"
+                "reference": "33c189bd51a510c1ceba67222395ead08a29863a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/kirschbaum-development/eloquent-power-joins/zipball/3f77b096c1e8b5aa1fc40d7080e55e795f3430ae",
-                "reference": "3f77b096c1e8b5aa1fc40d7080e55e795f3430ae",
+                "url": "https://api.github.com/repos/kirschbaum-development/eloquent-power-joins/zipball/33c189bd51a510c1ceba67222395ead08a29863a",
+                "reference": "33c189bd51a510c1ceba67222395ead08a29863a",
                 "shasum": ""
             },
             "require": {
@@ -8090,9 +8128,9 @@
             ],
             "support": {
                 "issues": "https://github.com/kirschbaum-development/eloquent-power-joins/issues",
-                "source": "https://github.com/kirschbaum-development/eloquent-power-joins/tree/4.3.1"
+                "source": "https://github.com/kirschbaum-development/eloquent-power-joins/tree/4.3.2"
             },
-            "time": "2026-03-29T12:05:03+00:00"
+            "time": "2026-05-28T20:35:55+00:00"
         },
         {
             "name": "larastan/larastan",
@@ -12439,22 +12477,22 @@
         },
         {
             "name": "symfony/html-sanitizer",
-            "version": "v8.0.13",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/html-sanitizer.git",
-                "reference": "6f9a7821ac2a9bc3c2230b6ba7012ce81fb6711e"
+                "reference": "adf86ad7e51344c0b121c9f8a26c95ea35b2b8fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/6f9a7821ac2a9bc3c2230b6ba7012ce81fb6711e",
-                "reference": "6f9a7821ac2a9bc3c2230b6ba7012ce81fb6711e",
+                "url": "https://api.github.com/repos/symfony/html-sanitizer/zipball/adf86ad7e51344c0b121c9f8a26c95ea35b2b8fc",
+                "reference": "adf86ad7e51344c0b121c9f8a26c95ea35b2b8fc",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "league/uri": "^6.5|^7.0",
-                "php": ">=8.4"
+                "php": ">=8.4.1"
             },
             "type": "library",
             "autoload": {
@@ -12487,7 +12525,7 @@
                 "sanitizer"
             ],
             "support": {
-                "source": "https://github.com/symfony/html-sanitizer/tree/v8.0.13"
+                "source": "https://github.com/symfony/html-sanitizer/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -12507,7 +12545,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-24T11:21:57+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/phpstan-filament-v3.neon
+++ b/phpstan-filament-v3.neon
@@ -3,8 +3,11 @@ includes:
 
 # Analyse the Filament v3 resources only. Run in the CI matrix cell where
 # filament/filament:3.* is installed. The `!` overrides the base config's
-# excludePaths so only the other two version dirs stay excluded.
+# exclude list so only the other two version dirs (and the facade) stay
+# excluded, leaving src/Filament/V3 analysed.
 parameters:
-    excludePaths!:
-        - src/Filament/V4
-        - src/Filament/V5
+    excludePaths:
+        analyseAndScan!:
+            - src/Filament/V4 (?)
+            - src/Filament/V5 (?)
+            - src/Filament/BlogPlugin.php

--- a/phpstan-filament-v3.neon
+++ b/phpstan-filament-v3.neon
@@ -1,0 +1,10 @@
+includes:
+    - phpstan.neon
+
+# Analyse the Filament v3 resources only. Run in the CI matrix cell where
+# filament/filament:3.* is installed. The `!` overrides the base config's
+# excludePaths so only the other two version dirs stay excluded.
+parameters:
+    excludePaths!:
+        - src/Filament/V4
+        - src/Filament/V5

--- a/phpstan-filament-v4.neon
+++ b/phpstan-filament-v4.neon
@@ -1,0 +1,10 @@
+includes:
+    - phpstan.neon
+
+# Analyse the Filament v4 resources only. Run in the CI matrix cell where
+# filament/filament:4.* is installed. The `!` overrides the base config's
+# excludePaths so only the other two version dirs stay excluded.
+parameters:
+    excludePaths!:
+        - src/Filament/V3
+        - src/Filament/V5

--- a/phpstan-filament-v4.neon
+++ b/phpstan-filament-v4.neon
@@ -3,8 +3,11 @@ includes:
 
 # Analyse the Filament v4 resources only. Run in the CI matrix cell where
 # filament/filament:4.* is installed. The `!` overrides the base config's
-# excludePaths so only the other two version dirs stay excluded.
+# exclude list so only the other two version dirs (and the facade) stay
+# excluded, leaving src/Filament/V4 analysed.
 parameters:
-    excludePaths!:
-        - src/Filament/V3
-        - src/Filament/V5
+    excludePaths:
+        analyseAndScan!:
+            - src/Filament/V3 (?)
+            - src/Filament/V5 (?)
+            - src/Filament/BlogPlugin.php

--- a/phpstan-filament-v5.neon
+++ b/phpstan-filament-v5.neon
@@ -3,9 +3,11 @@ includes:
 
 # Analyse the Filament v5 resources only. Run in the CI matrix cell where
 # filament/filament:5.* is installed (also the local dev default). The `!`
-# overrides the base config's excludePaths so only the other two version
-# dirs stay excluded.
+# overrides the base config's exclude list so only the other two version
+# dirs (and the facade) stay excluded, leaving src/Filament/V5 analysed.
 parameters:
-    excludePaths!:
-        - src/Filament/V3
-        - src/Filament/V4
+    excludePaths:
+        analyseAndScan!:
+            - src/Filament/V3 (?)
+            - src/Filament/V4 (?)
+            - src/Filament/BlogPlugin.php

--- a/phpstan-filament-v5.neon
+++ b/phpstan-filament-v5.neon
@@ -1,0 +1,11 @@
+includes:
+    - phpstan.neon
+
+# Analyse the Filament v5 resources only. Run in the CI matrix cell where
+# filament/filament:5.* is installed (also the local dev default). The `!`
+# overrides the base config's excludePaths so only the other two version
+# dirs stay excluded.
+parameters:
+    excludePaths!:
+        - src/Filament/V3
+        - src/Filament/V4

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -5,6 +5,16 @@ parameters:
     level: 8
     paths:
         - src
+    excludePaths:
+        # The three Filament version dirs reference mutually-exclusive
+        # namespaces; only one Filament major is ever installed. The base
+        # config analyses non-Filament src only. Each version dir is analysed
+        # by its matching phpstan-filament-v{3,4,5}.neon in the CI matrix.
+        # `(?)` marks them optional so analysis works whether or not the dir
+        # exists yet (and the per-version configs re-include this base).
+        - src/Filament/V3 (?)
+        - src/Filament/V4 (?)
+        - src/Filament/V5 (?)
     tmpDir: build/phpstan
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,15 +6,20 @@ parameters:
     paths:
         - src
     excludePaths:
-        # The three Filament version dirs reference mutually-exclusive
-        # namespaces; only one Filament major is ever installed. The base
-        # config analyses non-Filament src only. Each version dir is analysed
-        # by its matching phpstan-filament-v{3,4,5}.neon in the CI matrix.
-        # `(?)` marks them optional so analysis works whether or not the dir
-        # exists yet (and the per-version configs re-include this base).
-        - src/Filament/V3 (?)
-        - src/Filament/V4 (?)
-        - src/Filament/V5 (?)
+        analyseAndScan:
+            # The three Filament version dirs reference mutually-exclusive
+            # namespaces; only one Filament major is ever installed. The base
+            # config analyses non-Filament src only. Each version dir is
+            # analysed by its matching phpstan-filament-v{3,4,5}.neon in CI.
+            # `(?)` marks them optional so analysis works whether or not the
+            # dir exists yet (the per-version configs re-include this base).
+            - src/Filament/V3 (?)
+            - src/Filament/V4 (?)
+            - src/Filament/V5 (?)
+            # The version-dispatching facade is the one file that references
+            # all three version namespaces by design, so it cannot be analysed
+            # under any single-version config. Covered by runtime smoke tests.
+            - src/Filament/BlogPlugin.php
     tmpDir: build/phpstan
     reportUnmatchedIgnoredErrors: false
     ignoreErrors:

--- a/src/Filament/BlogPlugin.php
+++ b/src/Filament/BlogPlugin.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament;
+
+use Filament\Contracts\Plugin;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+/**
+ * Version-dispatching facade for the Blog Filament plugin.
+ *
+ * Register on a panel with `->plugin(\Kurt\Modules\Blog\Filament\BlogPlugin::make())`.
+ * The correct V{n} plugin is resolved from the installed Filament major, so the
+ * same call works whether the consumer runs Filament 3, 4, or 5.
+ */
+final class BlogPlugin
+{
+    public static function make(): Plugin
+    {
+        return match (FilamentVersion::major()) {
+            5 => new V5\BlogPlugin,
+            4 => new V4\BlogPlugin,
+            3 => new V3\BlogPlugin,
+            default => throw new \RuntimeException('Filament is not installed; cannot register the Blog plugin.'),
+        };
+    }
+}

--- a/src/Filament/V3/BlogPlugin.php
+++ b/src/Filament/V3/BlogPlugin.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3;
+
+use Filament\Contracts\Plugin;
+use Filament\Panel;
+use Kurt\Modules\Blog\Filament\V3\Resources\CategoryResource;
+use Kurt\Modules\Blog\Filament\V3\Resources\CommentResource;
+use Kurt\Modules\Blog\Filament\V3\Resources\PostResource;
+use Kurt\Modules\Blog\Filament\V3\Resources\TagResource;
+
+final class BlogPlugin implements Plugin
+{
+    public function getId(): string
+    {
+        return 'kurtmodules-blog';
+    }
+
+    public function register(Panel $panel): void
+    {
+        $panel->resources([
+            PostResource::class,
+            CategoryResource::class,
+            TagResource::class,
+            CommentResource::class,
+        ]);
+    }
+
+    public function boot(Panel $panel): void {}
+
+    public static function make(): static
+    {
+        /** @var static */
+        return app(self::class);
+    }
+}

--- a/src/Filament/V3/Resources/CategoryResource.php
+++ b/src/Filament/V3/Resources/CategoryResource.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources;
+
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Tabs;
+use Filament\Forms\Components\Tabs\Tab;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\DeleteBulkAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Kurt\Modules\Blog\Filament\V3\Resources\CategoryResource\Pages;
+use Kurt\Modules\Blog\Models\Category;
+
+class CategoryResource extends Resource
+{
+    protected static ?string $model = Category::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-rectangle-stack';
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    /** @var array<int, string> */
+    protected static array $locales = ['en', 'tr'];
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make()
+                    ->schema([
+                        Tabs::make('translations')
+                            ->tabs(array_map(
+                                fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                    ->schema([
+                                        TextInput::make("name.{$locale}")
+                                            ->label('Name')
+                                            ->required($locale === 'en')
+                                            ->maxLength(255),
+                                        Textarea::make("description.{$locale}")
+                                            ->label('Description')
+                                            ->rows(3),
+                                    ]),
+                                static::$locales,
+                            ))
+                            ->columnSpanFull(),
+                    ])
+                    ->columnSpanFull(),
+
+                Section::make()
+                    ->schema([
+                        TextInput::make('slug')
+                            ->maxLength(255)
+                            ->disabledOn('edit')
+                            ->dehydrated(false),
+                        Select::make('parent_id')
+                            ->relationship('parent', 'name')
+                            ->searchable()
+                            ->preload()
+                            ->label('Parent'),
+                        TextInput::make('position')
+                            ->numeric()
+                            ->default(0),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('slug')
+                    ->toggleable(),
+                TextColumn::make('parent.name')
+                    ->label('Parent')
+                    ->sortable()
+                    ->placeholder('—'),
+                TextColumn::make('posts_count')
+                    ->counts('posts')
+                    ->label('Posts'),
+                TextColumn::make('position')
+                    ->sortable(),
+            ])
+            ->defaultSort('position')
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListCategories::route('/'),
+            'create' => Pages\CreateCategory::route('/create'),
+            'edit' => Pages\EditCategory::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/V3/Resources/CategoryResource/Pages/CreateCategory.php
+++ b/src/Filament/V3/Resources/CategoryResource/Pages/CreateCategory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources\CategoryResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Kurt\Modules\Blog\Filament\V3\Resources\CategoryResource;
+
+class CreateCategory extends CreateRecord
+{
+    protected static string $resource = CategoryResource::class;
+}

--- a/src/Filament/V3/Resources/CategoryResource/Pages/EditCategory.php
+++ b/src/Filament/V3/Resources/CategoryResource/Pages/EditCategory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources\CategoryResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Kurt\Modules\Blog\Filament\V3\Resources\CategoryResource;
+
+class EditCategory extends EditRecord
+{
+    protected static string $resource = CategoryResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V3/Resources/CategoryResource/Pages/ListCategories.php
+++ b/src/Filament/V3/Resources/CategoryResource/Pages/ListCategories.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources\CategoryResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Kurt\Modules\Blog\Filament\V3\Resources\CategoryResource;
+
+class ListCategories extends ListRecords
+{
+    protected static string $resource = CategoryResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V3/Resources/CommentResource.php
+++ b/src/Filament/V3/Resources/CommentResource.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources;
+
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Form;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Tables\Actions\Action;
+use Filament\Tables\Actions\BulkAction;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\DeleteBulkAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Kurt\Modules\Blog\Enums\CommentApproval;
+use Kurt\Modules\Blog\Filament\V3\Resources\CommentResource\Pages;
+use Kurt\Modules\Blog\Models\Comment;
+
+class CommentResource extends Resource
+{
+    protected static ?string $model = Comment::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-chat-bubble-left-right';
+
+    protected static ?string $recordTitleAttribute = 'body';
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make()
+                    ->schema([
+                        Textarea::make('body')
+                            ->required()
+                            ->rows(5)
+                            ->columnSpanFull(),
+                        Select::make('approval')
+                            ->options(CommentApproval::class)
+                            ->required(),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('body')
+                    ->limit(60)
+                    ->searchable()
+                    ->wrap(),
+                TextColumn::make('approval')
+                    ->badge()
+                    ->color(fn (?CommentApproval $state): string => match ($state) {
+                        CommentApproval::Approved => 'success',
+                        CommentApproval::Rejected => 'danger',
+                        default => 'warning',
+                    })
+                    ->sortable(),
+                TextColumn::make('author.name')
+                    ->label('Author')
+                    ->toggleable(),
+                TextColumn::make('post.title')
+                    ->label('Post')
+                    ->limit(40)
+                    ->toggleable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(),
+            ])
+            ->filters([
+                SelectFilter::make('approval')
+                    ->options(CommentApproval::class)
+                    ->default(CommentApproval::Pending->value),
+            ])
+            ->actions([
+                Action::make('approve')
+                    ->icon('heroicon-m-check')
+                    ->color('success')
+                    ->requiresConfirmation()
+                    ->visible(fn (Comment $record): bool => $record->approval !== CommentApproval::Approved)
+                    ->action(fn (Comment $record) => $record->approve(static::moderator())),
+                Action::make('reject')
+                    ->icon('heroicon-m-x-mark')
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->visible(fn (Comment $record): bool => $record->approval !== CommentApproval::Rejected)
+                    ->action(fn (Comment $record) => $record->reject(static::moderator())),
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    BulkAction::make('approve')
+                        ->label('Approve selected')
+                        ->icon('heroicon-m-check')
+                        ->color('success')
+                        ->requiresConfirmation()
+                        ->deselectRecordsAfterCompletion()
+                        ->action(fn (Collection $records) => static::moderateEach($records, 'approve')),
+                    BulkAction::make('reject')
+                        ->label('Reject selected')
+                        ->icon('heroicon-m-x-mark')
+                        ->color('danger')
+                        ->requiresConfirmation()
+                        ->deselectRecordsAfterCompletion()
+                        ->action(fn (Collection $records) => static::moderateEach($records, 'reject')),
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    protected static function moderator(): Model
+    {
+        $user = Filament::auth()->user();
+
+        if (! $user instanceof Model) {
+            throw new \RuntimeException('A moderating user must be authenticated to approve or reject comments.');
+        }
+
+        return $user;
+    }
+
+    /**
+     * @param  Collection<int, Model>  $records
+     */
+    protected static function moderateEach(Collection $records, string $verb): void
+    {
+        $moderator = static::moderator();
+
+        foreach ($records as $record) {
+            if (! $record instanceof Comment) {
+                continue;
+            }
+
+            $verb === 'approve'
+                ? $record->approve($moderator)
+                : $record->reject($moderator);
+        }
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListComments::route('/'),
+            'edit' => Pages\EditComment::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/V3/Resources/CommentResource/Pages/EditComment.php
+++ b/src/Filament/V3/Resources/CommentResource/Pages/EditComment.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources\CommentResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Kurt\Modules\Blog\Filament\V3\Resources\CommentResource;
+
+class EditComment extends EditRecord
+{
+    protected static string $resource = CommentResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V3/Resources/CommentResource/Pages/ListComments.php
+++ b/src/Filament/V3/Resources/CommentResource/Pages/ListComments.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources\CommentResource\Pages;
+
+use Filament\Resources\Pages\ListRecords;
+use Kurt\Modules\Blog\Filament\V3\Resources\CommentResource;
+
+class ListComments extends ListRecords
+{
+    protected static string $resource = CommentResource::class;
+}

--- a/src/Filament/V3/Resources/PostResource.php
+++ b/src/Filament/V3/Resources/PostResource.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources;
+
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Fieldset;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use Filament\Forms\Components\Tabs;
+use Filament\Forms\Components\Tabs\Tab;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Forms\Get;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\DeleteBulkAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Kurt\Modules\Blog\Enums\PostStatus;
+use Kurt\Modules\Blog\Enums\PostType;
+use Kurt\Modules\Blog\Filament\V3\Resources\PostResource\Pages;
+use Kurt\Modules\Blog\Models\Post;
+
+class PostResource extends Resource
+{
+    protected static ?string $model = Post::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-document-text';
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    /** @var array<int, string> */
+    protected static array $locales = ['en', 'tr'];
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make()
+                    ->schema([
+                        Tabs::make('translations')
+                            ->tabs(array_map(
+                                fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                    ->schema([
+                                        TextInput::make("title.{$locale}")
+                                            ->label('Title')
+                                            ->required($locale === 'en')
+                                            ->maxLength(255),
+                                        Textarea::make("excerpt.{$locale}")
+                                            ->label('Excerpt')
+                                            ->rows(2),
+                                        Textarea::make("body.{$locale}")
+                                            ->label('Body')
+                                            ->rows(10),
+                                    ]),
+                                static::$locales,
+                            ))
+                            ->columnSpanFull(),
+                    ])
+                    ->columnSpanFull(),
+
+                Section::make('Details')
+                    ->schema([
+                        Select::make('status')
+                            ->options(PostStatus::class)
+                            ->default(PostStatus::Draft)
+                            ->required()
+                            ->live(),
+                        Select::make('type')
+                            ->options(PostType::class)
+                            ->default(PostType::Text)
+                            ->required()
+                            ->live(),
+                        DateTimePicker::make('scheduled_for')
+                            ->seconds(false)
+                            ->visible(fn (Get $get): bool => $get('status') === PostStatus::Scheduled->value),
+                        DateTimePicker::make('published_at')
+                            ->seconds(false),
+                        TextInput::make('video_url')
+                            ->url()
+                            ->maxLength(2048)
+                            ->visible(fn (Get $get): bool => $get('type') === PostType::Video->value),
+                        Select::make('category_id')
+                            ->relationship('category', 'name')
+                            ->searchable()
+                            ->preload()
+                            ->label('Category'),
+                        Select::make('tags')
+                            ->relationship('tags', 'name')
+                            ->multiple()
+                            ->searchable()
+                            ->preload()
+                            ->label('Tags'),
+                    ])
+                    ->columns(2),
+
+                Section::make('Cover')
+                    ->schema([
+                        SpatieMediaLibraryFileUpload::make('cover')
+                            ->collection('cover')
+                            ->image()
+                            ->visibility('public'),
+                    ]),
+
+                Fieldset::make('SEO')
+                    ->schema([
+                        Tabs::make('seo_translations')
+                            ->tabs(array_map(
+                                fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                    ->schema([
+                                        TextInput::make("meta_title.{$locale}")
+                                            ->label('Meta title')
+                                            ->maxLength(255),
+                                        Textarea::make("meta_description.{$locale}")
+                                            ->label('Meta description')
+                                            ->rows(2),
+                                    ]),
+                                static::$locales,
+                            ))
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('title')
+                    ->searchable()
+                    ->sortable()
+                    ->limit(50),
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (PostStatus $state): string => match ($state) {
+                        PostStatus::Draft => 'gray',
+                        PostStatus::Scheduled => 'warning',
+                        PostStatus::Published => 'success',
+                        PostStatus::Archived => 'danger',
+                    })
+                    ->sortable(),
+                TextColumn::make('type')
+                    ->badge()
+                    ->color('info'),
+                TextColumn::make('author.name')
+                    ->label('Author')
+                    ->toggleable(),
+                TextColumn::make('category.name')
+                    ->label('Category')
+                    ->toggleable(),
+                TextColumn::make('published_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('view_count')
+                    ->label('Views')
+                    ->numeric()
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(PostStatus::class),
+                SelectFilter::make('type')
+                    ->options(PostType::class),
+            ])
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    /**
+     * @return array<class-string, mixed>
+     */
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPosts::route('/'),
+            'create' => Pages\CreatePost::route('/create'),
+            'edit' => Pages\EditPost::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/V3/Resources/PostResource/Pages/CreatePost.php
+++ b/src/Filament/V3/Resources/PostResource/Pages/CreatePost.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources\PostResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Kurt\Modules\Blog\Filament\V3\Resources\PostResource;
+
+class CreatePost extends CreateRecord
+{
+    protected static string $resource = PostResource::class;
+}

--- a/src/Filament/V3/Resources/PostResource/Pages/EditPost.php
+++ b/src/Filament/V3/Resources/PostResource/Pages/EditPost.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources\PostResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Kurt\Modules\Blog\Filament\V3\Resources\PostResource;
+
+class EditPost extends EditRecord
+{
+    protected static string $resource = PostResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V3/Resources/PostResource/Pages/ListPosts.php
+++ b/src/Filament/V3/Resources/PostResource/Pages/ListPosts.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources\PostResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Kurt\Modules\Blog\Filament\V3\Resources\PostResource;
+
+class ListPosts extends ListRecords
+{
+    protected static string $resource = PostResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V3/Resources/TagResource.php
+++ b/src/Filament/V3/Resources/TagResource.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources;
+
+use Filament\Forms\Components\ColorPicker;
+use Filament\Forms\Components\Section;
+use Filament\Forms\Components\Tabs;
+use Filament\Forms\Components\Tabs\Tab;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Forms\Form;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Tables\Actions\BulkActionGroup;
+use Filament\Tables\Actions\DeleteAction;
+use Filament\Tables\Actions\DeleteBulkAction;
+use Filament\Tables\Actions\EditAction;
+use Filament\Tables\Columns\ColorColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Kurt\Modules\Blog\Filament\V3\Resources\TagResource\Pages;
+use Kurt\Modules\Blog\Models\Tag;
+
+class TagResource extends Resource
+{
+    protected static ?string $model = Tag::class;
+
+    protected static ?string $navigationIcon = 'heroicon-o-tag';
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    /** @var array<int, string> */
+    protected static array $locales = ['en', 'tr'];
+
+    public static function form(Form $form): Form
+    {
+        return $form
+            ->schema([
+                Section::make()
+                    ->schema([
+                        Tabs::make('translations')
+                            ->tabs(array_map(
+                                fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                    ->schema([
+                                        TextInput::make("name.{$locale}")
+                                            ->label('Name')
+                                            ->required($locale === 'en')
+                                            ->maxLength(255),
+                                        Textarea::make("description.{$locale}")
+                                            ->label('Description')
+                                            ->rows(3),
+                                    ]),
+                                static::$locales,
+                            ))
+                            ->columnSpanFull(),
+                    ])
+                    ->columnSpanFull(),
+
+                Section::make()
+                    ->schema([
+                        ColorPicker::make('color'),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                ColorColumn::make('color'),
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('slug')
+                    ->toggleable(),
+                TextColumn::make('posts_count')
+                    ->counts('posts')
+                    ->label('Posts'),
+            ])
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListTags::route('/'),
+            'create' => Pages\CreateTag::route('/create'),
+            'edit' => Pages\EditTag::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/V3/Resources/TagResource/Pages/CreateTag.php
+++ b/src/Filament/V3/Resources/TagResource/Pages/CreateTag.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources\TagResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Kurt\Modules\Blog\Filament\V3\Resources\TagResource;
+
+class CreateTag extends CreateRecord
+{
+    protected static string $resource = TagResource::class;
+}

--- a/src/Filament/V3/Resources/TagResource/Pages/EditTag.php
+++ b/src/Filament/V3/Resources/TagResource/Pages/EditTag.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources\TagResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Kurt\Modules\Blog\Filament\V3\Resources\TagResource;
+
+class EditTag extends EditRecord
+{
+    protected static string $resource = TagResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V3/Resources/TagResource/Pages/ListTags.php
+++ b/src/Filament/V3/Resources/TagResource/Pages/ListTags.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V3\Resources\TagResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Kurt\Modules\Blog\Filament\V3\Resources\TagResource;
+
+class ListTags extends ListRecords
+{
+    protected static string $resource = TagResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V4/BlogPlugin.php
+++ b/src/Filament/V4/BlogPlugin.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4;
+
+use Filament\Contracts\Plugin;
+use Filament\Panel;
+use Kurt\Modules\Blog\Filament\V4\Resources\CategoryResource;
+use Kurt\Modules\Blog\Filament\V4\Resources\CommentResource;
+use Kurt\Modules\Blog\Filament\V4\Resources\PostResource;
+use Kurt\Modules\Blog\Filament\V4\Resources\TagResource;
+
+final class BlogPlugin implements Plugin
+{
+    public function getId(): string
+    {
+        return 'kurtmodules-blog';
+    }
+
+    public function register(Panel $panel): void
+    {
+        $panel->resources([
+            PostResource::class,
+            CategoryResource::class,
+            TagResource::class,
+            CommentResource::class,
+        ]);
+    }
+
+    public function boot(Panel $panel): void {}
+
+    public static function make(): static
+    {
+        /** @var static */
+        return app(self::class);
+    }
+}

--- a/src/Filament/V4/Resources/CategoryResource.php
+++ b/src/Filament/V4/Resources/CategoryResource.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Kurt\Modules\Blog\Filament\V4\Resources\CategoryResource\Pages;
+use Kurt\Modules\Blog\Models\Category;
+
+class CategoryResource extends Resource
+{
+    protected static ?string $model = Category::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    /** @var array<int, string> */
+    protected static array $locales = ['en', 'tr'];
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make()
+                    ->schema([
+                        Tabs::make('translations')
+                            ->tabs(array_map(
+                                fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                    ->schema([
+                                        TextInput::make("name.{$locale}")
+                                            ->label('Name')
+                                            ->required($locale === 'en')
+                                            ->maxLength(255),
+                                        Textarea::make("description.{$locale}")
+                                            ->label('Description')
+                                            ->rows(3),
+                                    ]),
+                                static::$locales,
+                            ))
+                            ->columnSpanFull(),
+                    ])
+                    ->columnSpanFull(),
+
+                Section::make()
+                    ->schema([
+                        TextInput::make('slug')
+                            ->maxLength(255)
+                            ->disabledOn('edit')
+                            ->dehydrated(false),
+                        Select::make('parent_id')
+                            ->relationship('parent', 'name')
+                            ->searchable()
+                            ->preload()
+                            ->label('Parent'),
+                        TextInput::make('position')
+                            ->numeric()
+                            ->default(0),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('slug')
+                    ->toggleable(),
+                TextColumn::make('parent.name')
+                    ->label('Parent')
+                    ->sortable()
+                    ->placeholder('—'),
+                TextColumn::make('posts_count')
+                    ->counts('posts')
+                    ->label('Posts'),
+                TextColumn::make('position')
+                    ->sortable(),
+            ])
+            ->defaultSort('position')
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListCategories::route('/'),
+            'create' => Pages\CreateCategory::route('/create'),
+            'edit' => Pages\EditCategory::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/V4/Resources/CategoryResource/Pages/CreateCategory.php
+++ b/src/Filament/V4/Resources/CategoryResource/Pages/CreateCategory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources\CategoryResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Kurt\Modules\Blog\Filament\V4\Resources\CategoryResource;
+
+class CreateCategory extends CreateRecord
+{
+    protected static string $resource = CategoryResource::class;
+}

--- a/src/Filament/V4/Resources/CategoryResource/Pages/EditCategory.php
+++ b/src/Filament/V4/Resources/CategoryResource/Pages/EditCategory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources\CategoryResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Kurt\Modules\Blog\Filament\V4\Resources\CategoryResource;
+
+class EditCategory extends EditRecord
+{
+    protected static string $resource = CategoryResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V4/Resources/CategoryResource/Pages/ListCategories.php
+++ b/src/Filament/V4/Resources/CategoryResource/Pages/ListCategories.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources\CategoryResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Kurt\Modules\Blog\Filament\V4\Resources\CategoryResource;
+
+class ListCategories extends ListRecords
+{
+    protected static string $resource = CategoryResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V4/Resources/CommentResource.php
+++ b/src/Filament/V4/Resources/CommentResource.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources;
+
+use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Kurt\Modules\Blog\Enums\CommentApproval;
+use Kurt\Modules\Blog\Filament\V4\Resources\CommentResource\Pages;
+use Kurt\Modules\Blog\Models\Comment;
+
+class CommentResource extends Resource
+{
+    protected static ?string $model = Comment::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedChatBubbleLeftRight;
+
+    protected static ?string $recordTitleAttribute = 'body';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make()
+                    ->schema([
+                        Textarea::make('body')
+                            ->required()
+                            ->rows(5)
+                            ->columnSpanFull(),
+                        Select::make('approval')
+                            ->options(CommentApproval::class)
+                            ->required(),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('body')
+                    ->limit(60)
+                    ->searchable()
+                    ->wrap(),
+                TextColumn::make('approval')
+                    ->badge()
+                    ->color(fn (?CommentApproval $state): string => match ($state) {
+                        CommentApproval::Approved => 'success',
+                        CommentApproval::Rejected => 'danger',
+                        default => 'warning',
+                    })
+                    ->sortable(),
+                TextColumn::make('author.name')
+                    ->label('Author')
+                    ->toggleable(),
+                TextColumn::make('post.title')
+                    ->label('Post')
+                    ->limit(40)
+                    ->toggleable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(),
+            ])
+            ->filters([
+                SelectFilter::make('approval')
+                    ->options(CommentApproval::class)
+                    ->default(CommentApproval::Pending->value),
+            ])
+            ->recordActions([
+                Action::make('approve')
+                    ->icon(Heroicon::Check)
+                    ->color('success')
+                    ->requiresConfirmation()
+                    ->visible(fn (Comment $record): bool => $record->approval !== CommentApproval::Approved)
+                    ->action(fn (Comment $record) => $record->approve(static::moderator())),
+                Action::make('reject')
+                    ->icon(Heroicon::XMark)
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->visible(fn (Comment $record): bool => $record->approval !== CommentApproval::Rejected)
+                    ->action(fn (Comment $record) => $record->reject(static::moderator())),
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    BulkAction::make('approve')
+                        ->label('Approve selected')
+                        ->icon(Heroicon::Check)
+                        ->color('success')
+                        ->requiresConfirmation()
+                        ->deselectRecordsAfterCompletion()
+                        ->action(fn (Collection $records) => static::moderateEach($records, 'approve')),
+                    BulkAction::make('reject')
+                        ->label('Reject selected')
+                        ->icon(Heroicon::XMark)
+                        ->color('danger')
+                        ->requiresConfirmation()
+                        ->deselectRecordsAfterCompletion()
+                        ->action(fn (Collection $records) => static::moderateEach($records, 'reject')),
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    protected static function moderator(): Model
+    {
+        $user = Filament::auth()->user();
+
+        if (! $user instanceof Model) {
+            throw new \RuntimeException('A moderating user must be authenticated to approve or reject comments.');
+        }
+
+        return $user;
+    }
+
+    /**
+     * @param  Collection<int, Model>  $records
+     */
+    protected static function moderateEach(Collection $records, string $verb): void
+    {
+        $moderator = static::moderator();
+
+        foreach ($records as $record) {
+            if (! $record instanceof Comment) {
+                continue;
+            }
+
+            $verb === 'approve'
+                ? $record->approve($moderator)
+                : $record->reject($moderator);
+        }
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListComments::route('/'),
+            'edit' => Pages\EditComment::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/V4/Resources/CommentResource/Pages/EditComment.php
+++ b/src/Filament/V4/Resources/CommentResource/Pages/EditComment.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources\CommentResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Kurt\Modules\Blog\Filament\V4\Resources\CommentResource;
+
+class EditComment extends EditRecord
+{
+    protected static string $resource = CommentResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V4/Resources/CommentResource/Pages/ListComments.php
+++ b/src/Filament/V4/Resources/CommentResource/Pages/ListComments.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources\CommentResource\Pages;
+
+use Filament\Resources\Pages\ListRecords;
+use Kurt\Modules\Blog\Filament\V4\Resources\CommentResource;
+
+class ListComments extends ListRecords
+{
+    protected static string $resource = CommentResource::class;
+}

--- a/src/Filament/V4/Resources/PostResource.php
+++ b/src/Filament/V4/Resources/PostResource.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Fieldset;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Kurt\Modules\Blog\Enums\PostStatus;
+use Kurt\Modules\Blog\Enums\PostType;
+use Kurt\Modules\Blog\Filament\V4\Resources\PostResource\Pages;
+use Kurt\Modules\Blog\Models\Post;
+
+class PostResource extends Resource
+{
+    protected static ?string $model = Post::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentText;
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    /** @var array<int, string> */
+    protected static array $locales = ['en', 'tr'];
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make()
+                    ->schema([
+                        Tabs::make('translations')
+                            ->tabs(array_map(
+                                fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                    ->schema([
+                                        TextInput::make("title.{$locale}")
+                                            ->label('Title')
+                                            ->required($locale === 'en')
+                                            ->maxLength(255),
+                                        Textarea::make("excerpt.{$locale}")
+                                            ->label('Excerpt')
+                                            ->rows(2),
+                                        Textarea::make("body.{$locale}")
+                                            ->label('Body')
+                                            ->rows(10),
+                                    ]),
+                                static::$locales,
+                            ))
+                            ->columnSpanFull(),
+                    ])
+                    ->columnSpanFull(),
+
+                Section::make('Details')
+                    ->schema([
+                        Select::make('status')
+                            ->options(PostStatus::class)
+                            ->default(PostStatus::Draft)
+                            ->required()
+                            ->live(),
+                        Select::make('type')
+                            ->options(PostType::class)
+                            ->default(PostType::Text)
+                            ->required()
+                            ->live(),
+                        DateTimePicker::make('scheduled_for')
+                            ->seconds(false)
+                            ->visible(fn (Get $get): bool => $get('status') === PostStatus::Scheduled->value),
+                        DateTimePicker::make('published_at')
+                            ->seconds(false),
+                        TextInput::make('video_url')
+                            ->url()
+                            ->maxLength(2048)
+                            ->visible(fn (Get $get): bool => $get('type') === PostType::Video->value),
+                        Select::make('category_id')
+                            ->relationship('category', 'name')
+                            ->searchable()
+                            ->preload()
+                            ->label('Category'),
+                        Select::make('tags')
+                            ->relationship('tags', 'name')
+                            ->multiple()
+                            ->searchable()
+                            ->preload()
+                            ->label('Tags'),
+                    ])
+                    ->columns(2),
+
+                Section::make('Cover')
+                    ->schema([
+                        SpatieMediaLibraryFileUpload::make('cover')
+                            ->collection('cover')
+                            ->image()
+                            ->visibility('public'),
+                    ]),
+
+                Fieldset::make('SEO')
+                    ->schema([
+                        Tabs::make('seo_translations')
+                            ->tabs(array_map(
+                                fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                    ->schema([
+                                        TextInput::make("meta_title.{$locale}")
+                                            ->label('Meta title')
+                                            ->maxLength(255),
+                                        Textarea::make("meta_description.{$locale}")
+                                            ->label('Meta description')
+                                            ->rows(2),
+                                    ]),
+                                static::$locales,
+                            ))
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('title')
+                    ->searchable()
+                    ->sortable()
+                    ->limit(50),
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (PostStatus $state): string => match ($state) {
+                        PostStatus::Draft => 'gray',
+                        PostStatus::Scheduled => 'warning',
+                        PostStatus::Published => 'success',
+                        PostStatus::Archived => 'danger',
+                    })
+                    ->sortable(),
+                TextColumn::make('type')
+                    ->badge()
+                    ->color('info'),
+                TextColumn::make('author.name')
+                    ->label('Author')
+                    ->toggleable(),
+                TextColumn::make('category.name')
+                    ->label('Category')
+                    ->toggleable(),
+                TextColumn::make('published_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('view_count')
+                    ->label('Views')
+                    ->numeric()
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(PostStatus::class),
+                SelectFilter::make('type')
+                    ->options(PostType::class),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    /**
+     * @return array<class-string, mixed>
+     */
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPosts::route('/'),
+            'create' => Pages\CreatePost::route('/create'),
+            'edit' => Pages\EditPost::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/V4/Resources/PostResource/Pages/CreatePost.php
+++ b/src/Filament/V4/Resources/PostResource/Pages/CreatePost.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources\PostResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Kurt\Modules\Blog\Filament\V4\Resources\PostResource;
+
+class CreatePost extends CreateRecord
+{
+    protected static string $resource = PostResource::class;
+}

--- a/src/Filament/V4/Resources/PostResource/Pages/EditPost.php
+++ b/src/Filament/V4/Resources/PostResource/Pages/EditPost.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources\PostResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Kurt\Modules\Blog\Filament\V4\Resources\PostResource;
+
+class EditPost extends EditRecord
+{
+    protected static string $resource = PostResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V4/Resources/PostResource/Pages/ListPosts.php
+++ b/src/Filament/V4/Resources/PostResource/Pages/ListPosts.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources\PostResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Kurt\Modules\Blog\Filament\V4\Resources\PostResource;
+
+class ListPosts extends ListRecords
+{
+    protected static string $resource = PostResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V4/Resources/TagResource.php
+++ b/src/Filament/V4/Resources/TagResource.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\ColorPicker;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\ColorColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Kurt\Modules\Blog\Filament\V4\Resources\TagResource\Pages;
+use Kurt\Modules\Blog\Models\Tag;
+
+class TagResource extends Resource
+{
+    protected static ?string $model = Tag::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedTag;
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    /** @var array<int, string> */
+    protected static array $locales = ['en', 'tr'];
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make()
+                    ->schema([
+                        Tabs::make('translations')
+                            ->tabs(array_map(
+                                fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                    ->schema([
+                                        TextInput::make("name.{$locale}")
+                                            ->label('Name')
+                                            ->required($locale === 'en')
+                                            ->maxLength(255),
+                                        Textarea::make("description.{$locale}")
+                                            ->label('Description')
+                                            ->rows(3),
+                                    ]),
+                                static::$locales,
+                            ))
+                            ->columnSpanFull(),
+                    ])
+                    ->columnSpanFull(),
+
+                Section::make()
+                    ->schema([
+                        ColorPicker::make('color'),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                ColorColumn::make('color'),
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('slug')
+                    ->toggleable(),
+                TextColumn::make('posts_count')
+                    ->counts('posts')
+                    ->label('Posts'),
+            ])
+            ->recordActions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->toolbarActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListTags::route('/'),
+            'create' => Pages\CreateTag::route('/create'),
+            'edit' => Pages\EditTag::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/V4/Resources/TagResource/Pages/CreateTag.php
+++ b/src/Filament/V4/Resources/TagResource/Pages/CreateTag.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources\TagResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Kurt\Modules\Blog\Filament\V4\Resources\TagResource;
+
+class CreateTag extends CreateRecord
+{
+    protected static string $resource = TagResource::class;
+}

--- a/src/Filament/V4/Resources/TagResource/Pages/EditTag.php
+++ b/src/Filament/V4/Resources/TagResource/Pages/EditTag.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources\TagResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Kurt\Modules\Blog\Filament\V4\Resources\TagResource;
+
+class EditTag extends EditRecord
+{
+    protected static string $resource = TagResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V4/Resources/TagResource/Pages/ListTags.php
+++ b/src/Filament/V4/Resources/TagResource/Pages/ListTags.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V4\Resources\TagResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Kurt\Modules\Blog\Filament\V4\Resources\TagResource;
+
+class ListTags extends ListRecords
+{
+    protected static string $resource = TagResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V5/BlogPlugin.php
+++ b/src/Filament/V5/BlogPlugin.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5;
+
+use Filament\Contracts\Plugin;
+use Filament\Panel;
+use Kurt\Modules\Blog\Filament\V5\Resources\CategoryResource;
+use Kurt\Modules\Blog\Filament\V5\Resources\CommentResource;
+use Kurt\Modules\Blog\Filament\V5\Resources\PostResource;
+use Kurt\Modules\Blog\Filament\V5\Resources\TagResource;
+
+final class BlogPlugin implements Plugin
+{
+    public function getId(): string
+    {
+        return 'kurtmodules-blog';
+    }
+
+    public function register(Panel $panel): void
+    {
+        $panel->resources([
+            PostResource::class,
+            CategoryResource::class,
+            TagResource::class,
+            CommentResource::class,
+        ]);
+    }
+
+    public function boot(Panel $panel): void {}
+
+    public static function make(): static
+    {
+        /** @var static */
+        return app(self::class);
+    }
+}

--- a/src/Filament/V5/Resources/CategoryResource.php
+++ b/src/Filament/V5/Resources/CategoryResource.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Kurt\Modules\Blog\Filament\V5\Resources\CategoryResource\Pages;
+use Kurt\Modules\Blog\Models\Category;
+
+class CategoryResource extends Resource
+{
+    protected static ?string $model = Category::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedRectangleStack;
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    /** @var array<int, string> */
+    protected static array $locales = ['en', 'tr'];
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make()
+                    ->schema([
+                        Tabs::make('translations')
+                            ->tabs(array_map(
+                                fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                    ->schema([
+                                        TextInput::make("name.{$locale}")
+                                            ->label('Name')
+                                            ->required($locale === 'en')
+                                            ->maxLength(255),
+                                        Textarea::make("description.{$locale}")
+                                            ->label('Description')
+                                            ->rows(3),
+                                    ]),
+                                static::$locales,
+                            ))
+                            ->columnSpanFull(),
+                    ])
+                    ->columnSpanFull(),
+
+                Section::make()
+                    ->schema([
+                        TextInput::make('slug')
+                            ->maxLength(255)
+                            ->disabledOn('edit')
+                            ->dehydrated(false),
+                        Select::make('parent_id')
+                            ->relationship('parent', 'name')
+                            ->searchable()
+                            ->preload()
+                            ->label('Parent'),
+                        TextInput::make('position')
+                            ->numeric()
+                            ->default(0),
+                    ])
+                    ->columns(2),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('slug')
+                    ->toggleable(),
+                TextColumn::make('parent.name')
+                    ->label('Parent')
+                    ->sortable()
+                    ->placeholder('—'),
+                TextColumn::make('posts_count')
+                    ->counts('posts')
+                    ->label('Posts'),
+                TextColumn::make('position')
+                    ->sortable(),
+            ])
+            ->defaultSort('position')
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListCategories::route('/'),
+            'create' => Pages\CreateCategory::route('/create'),
+            'edit' => Pages\EditCategory::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/V5/Resources/CategoryResource/Pages/CreateCategory.php
+++ b/src/Filament/V5/Resources/CategoryResource/Pages/CreateCategory.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources\CategoryResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Kurt\Modules\Blog\Filament\V5\Resources\CategoryResource;
+
+class CreateCategory extends CreateRecord
+{
+    protected static string $resource = CategoryResource::class;
+}

--- a/src/Filament/V5/Resources/CategoryResource/Pages/EditCategory.php
+++ b/src/Filament/V5/Resources/CategoryResource/Pages/EditCategory.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources\CategoryResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Kurt\Modules\Blog\Filament\V5\Resources\CategoryResource;
+
+class EditCategory extends EditRecord
+{
+    protected static string $resource = CategoryResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V5/Resources/CategoryResource/Pages/ListCategories.php
+++ b/src/Filament/V5/Resources/CategoryResource/Pages/ListCategories.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources\CategoryResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Kurt\Modules\Blog\Filament\V5\Resources\CategoryResource;
+
+class ListCategories extends ListRecords
+{
+    protected static string $resource = CategoryResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V5/Resources/CommentResource.php
+++ b/src/Filament/V5/Resources/CommentResource.php
@@ -1,0 +1,164 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources;
+
+use Filament\Actions\Action;
+use Filament\Actions\BulkAction;
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\Textarea;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\Model;
+use Kurt\Modules\Blog\Enums\CommentApproval;
+use Kurt\Modules\Blog\Filament\V5\Resources\CommentResource\Pages;
+use Kurt\Modules\Blog\Models\Comment;
+
+class CommentResource extends Resource
+{
+    protected static ?string $model = Comment::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedChatBubbleLeftRight;
+
+    protected static ?string $recordTitleAttribute = 'body';
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make()
+                    ->schema([
+                        Textarea::make('body')
+                            ->required()
+                            ->rows(5)
+                            ->columnSpanFull(),
+                        Select::make('approval')
+                            ->options(CommentApproval::class)
+                            ->required(),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('body')
+                    ->limit(60)
+                    ->searchable()
+                    ->wrap(),
+                TextColumn::make('approval')
+                    ->badge()
+                    ->color(fn (?CommentApproval $state): string => match ($state) {
+                        CommentApproval::Approved => 'success',
+                        CommentApproval::Rejected => 'danger',
+                        default => 'warning',
+                    })
+                    ->sortable(),
+                TextColumn::make('author.name')
+                    ->label('Author')
+                    ->toggleable(),
+                TextColumn::make('post.title')
+                    ->label('Post')
+                    ->limit(40)
+                    ->toggleable(),
+                TextColumn::make('created_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(),
+            ])
+            ->filters([
+                SelectFilter::make('approval')
+                    ->options(CommentApproval::class)
+                    ->default(CommentApproval::Pending->value),
+            ])
+            ->actions([
+                Action::make('approve')
+                    ->icon(Heroicon::Check)
+                    ->color('success')
+                    ->requiresConfirmation()
+                    ->visible(fn (Comment $record): bool => $record->approval !== CommentApproval::Approved)
+                    ->action(fn (Comment $record) => $record->approve(static::moderator())),
+                Action::make('reject')
+                    ->icon(Heroicon::XMark)
+                    ->color('danger')
+                    ->requiresConfirmation()
+                    ->visible(fn (Comment $record): bool => $record->approval !== CommentApproval::Rejected)
+                    ->action(fn (Comment $record) => $record->reject(static::moderator())),
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    BulkAction::make('approve')
+                        ->label('Approve selected')
+                        ->icon(Heroicon::Check)
+                        ->color('success')
+                        ->requiresConfirmation()
+                        ->deselectRecordsAfterCompletion()
+                        ->action(fn (Collection $records) => static::moderateEach($records, 'approve')),
+                    BulkAction::make('reject')
+                        ->label('Reject selected')
+                        ->icon(Heroicon::XMark)
+                        ->color('danger')
+                        ->requiresConfirmation()
+                        ->deselectRecordsAfterCompletion()
+                        ->action(fn (Collection $records) => static::moderateEach($records, 'reject')),
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    protected static function moderator(): Model
+    {
+        $user = Filament::auth()->user();
+
+        if (! $user instanceof Model) {
+            throw new \RuntimeException('A moderating user must be authenticated to approve or reject comments.');
+        }
+
+        return $user;
+    }
+
+    /**
+     * @param  Collection<int, Model>  $records
+     */
+    protected static function moderateEach(Collection $records, string $verb): void
+    {
+        $moderator = static::moderator();
+
+        foreach ($records as $record) {
+            if (! $record instanceof Comment) {
+                continue;
+            }
+
+            $verb === 'approve'
+                ? $record->approve($moderator)
+                : $record->reject($moderator);
+        }
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListComments::route('/'),
+            'edit' => Pages\EditComment::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/V5/Resources/CommentResource/Pages/EditComment.php
+++ b/src/Filament/V5/Resources/CommentResource/Pages/EditComment.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources\CommentResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Kurt\Modules\Blog\Filament\V5\Resources\CommentResource;
+
+class EditComment extends EditRecord
+{
+    protected static string $resource = CommentResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V5/Resources/CommentResource/Pages/ListComments.php
+++ b/src/Filament/V5/Resources/CommentResource/Pages/ListComments.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources\CommentResource\Pages;
+
+use Filament\Resources\Pages\ListRecords;
+use Kurt\Modules\Blog\Filament\V5\Resources\CommentResource;
+
+class ListComments extends ListRecords
+{
+    protected static string $resource = CommentResource::class;
+}

--- a/src/Filament/V5/Resources/PostResource.php
+++ b/src/Filament/V5/Resources/PostResource.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\Select;
+use Filament\Forms\Components\SpatieMediaLibraryFileUpload;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Fieldset;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Components\Utilities\Get;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Kurt\Modules\Blog\Enums\PostStatus;
+use Kurt\Modules\Blog\Enums\PostType;
+use Kurt\Modules\Blog\Filament\V5\Resources\PostResource\Pages;
+use Kurt\Modules\Blog\Models\Post;
+
+class PostResource extends Resource
+{
+    protected static ?string $model = Post::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedDocumentText;
+
+    protected static ?string $recordTitleAttribute = 'title';
+
+    /** @var array<int, string> */
+    protected static array $locales = ['en', 'tr'];
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make()
+                    ->schema([
+                        Tabs::make('translations')
+                            ->tabs(array_map(
+                                fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                    ->schema([
+                                        TextInput::make("title.{$locale}")
+                                            ->label('Title')
+                                            ->required($locale === 'en')
+                                            ->maxLength(255),
+                                        Textarea::make("excerpt.{$locale}")
+                                            ->label('Excerpt')
+                                            ->rows(2),
+                                        Textarea::make("body.{$locale}")
+                                            ->label('Body')
+                                            ->rows(10),
+                                    ]),
+                                static::$locales,
+                            ))
+                            ->columnSpanFull(),
+                    ])
+                    ->columnSpanFull(),
+
+                Section::make('Details')
+                    ->schema([
+                        Select::make('status')
+                            ->options(PostStatus::class)
+                            ->default(PostStatus::Draft)
+                            ->required()
+                            ->live(),
+                        Select::make('type')
+                            ->options(PostType::class)
+                            ->default(PostType::Text)
+                            ->required()
+                            ->live(),
+                        DateTimePicker::make('scheduled_for')
+                            ->seconds(false)
+                            ->visible(fn (Get $get): bool => $get('status') === PostStatus::Scheduled->value),
+                        DateTimePicker::make('published_at')
+                            ->seconds(false),
+                        TextInput::make('video_url')
+                            ->url()
+                            ->maxLength(2048)
+                            ->visible(fn (Get $get): bool => $get('type') === PostType::Video->value),
+                        Select::make('category_id')
+                            ->relationship('category', 'name')
+                            ->searchable()
+                            ->preload()
+                            ->label('Category'),
+                        Select::make('tags')
+                            ->relationship('tags', 'name')
+                            ->multiple()
+                            ->searchable()
+                            ->preload()
+                            ->label('Tags'),
+                    ])
+                    ->columns(2),
+
+                Section::make('Cover')
+                    ->schema([
+                        SpatieMediaLibraryFileUpload::make('cover')
+                            ->collection('cover')
+                            ->image()
+                            ->visibility('public'),
+                    ]),
+
+                Fieldset::make('SEO')
+                    ->schema([
+                        Tabs::make('seo_translations')
+                            ->tabs(array_map(
+                                fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                    ->schema([
+                                        TextInput::make("meta_title.{$locale}")
+                                            ->label('Meta title')
+                                            ->maxLength(255),
+                                        Textarea::make("meta_description.{$locale}")
+                                            ->label('Meta description')
+                                            ->rows(2),
+                                    ]),
+                                static::$locales,
+                            ))
+                            ->columnSpanFull(),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                TextColumn::make('title')
+                    ->searchable()
+                    ->sortable()
+                    ->limit(50),
+                TextColumn::make('status')
+                    ->badge()
+                    ->color(fn (PostStatus $state): string => match ($state) {
+                        PostStatus::Draft => 'gray',
+                        PostStatus::Scheduled => 'warning',
+                        PostStatus::Published => 'success',
+                        PostStatus::Archived => 'danger',
+                    })
+                    ->sortable(),
+                TextColumn::make('type')
+                    ->badge()
+                    ->color('info'),
+                TextColumn::make('author.name')
+                    ->label('Author')
+                    ->toggleable(),
+                TextColumn::make('category.name')
+                    ->label('Category')
+                    ->toggleable(),
+                TextColumn::make('published_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(),
+                TextColumn::make('view_count')
+                    ->label('Views')
+                    ->numeric()
+                    ->sortable(),
+            ])
+            ->filters([
+                SelectFilter::make('status')
+                    ->options(PostStatus::class),
+                SelectFilter::make('type')
+                    ->options(PostType::class),
+            ])
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    /**
+     * @return array<class-string, mixed>
+     */
+    public static function getRelations(): array
+    {
+        return [];
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListPosts::route('/'),
+            'create' => Pages\CreatePost::route('/create'),
+            'edit' => Pages\EditPost::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/V5/Resources/PostResource/Pages/CreatePost.php
+++ b/src/Filament/V5/Resources/PostResource/Pages/CreatePost.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources\PostResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Kurt\Modules\Blog\Filament\V5\Resources\PostResource;
+
+class CreatePost extends CreateRecord
+{
+    protected static string $resource = PostResource::class;
+}

--- a/src/Filament/V5/Resources/PostResource/Pages/EditPost.php
+++ b/src/Filament/V5/Resources/PostResource/Pages/EditPost.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources\PostResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Kurt\Modules\Blog\Filament\V5\Resources\PostResource;
+
+class EditPost extends EditRecord
+{
+    protected static string $resource = PostResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V5/Resources/PostResource/Pages/ListPosts.php
+++ b/src/Filament/V5/Resources/PostResource/Pages/ListPosts.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources\PostResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Kurt\Modules\Blog\Filament\V5\Resources\PostResource;
+
+class ListPosts extends ListRecords
+{
+    protected static string $resource = PostResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V5/Resources/TagResource.php
+++ b/src/Filament/V5/Resources/TagResource.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources;
+
+use Filament\Actions\BulkActionGroup;
+use Filament\Actions\DeleteAction;
+use Filament\Actions\DeleteBulkAction;
+use Filament\Actions\EditAction;
+use Filament\Forms\Components\ColorPicker;
+use Filament\Forms\Components\Textarea;
+use Filament\Forms\Components\TextInput;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\Tabs;
+use Filament\Schemas\Components\Tabs\Tab;
+use Filament\Schemas\Schema;
+use Filament\Support\Icons\Heroicon;
+use Filament\Tables\Columns\ColorColumn;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Table;
+use Kurt\Modules\Blog\Filament\V5\Resources\TagResource\Pages;
+use Kurt\Modules\Blog\Models\Tag;
+
+class TagResource extends Resource
+{
+    protected static ?string $model = Tag::class;
+
+    protected static string|\BackedEnum|null $navigationIcon = Heroicon::OutlinedTag;
+
+    protected static ?string $recordTitleAttribute = 'name';
+
+    /** @var array<int, string> */
+    protected static array $locales = ['en', 'tr'];
+
+    public static function form(Schema $schema): Schema
+    {
+        return $schema
+            ->components([
+                Section::make()
+                    ->schema([
+                        Tabs::make('translations')
+                            ->tabs(array_map(
+                                fn (string $locale): Tab => Tab::make(strtoupper($locale))
+                                    ->schema([
+                                        TextInput::make("name.{$locale}")
+                                            ->label('Name')
+                                            ->required($locale === 'en')
+                                            ->maxLength(255),
+                                        Textarea::make("description.{$locale}")
+                                            ->label('Description')
+                                            ->rows(3),
+                                    ]),
+                                static::$locales,
+                            ))
+                            ->columnSpanFull(),
+                    ])
+                    ->columnSpanFull(),
+
+                Section::make()
+                    ->schema([
+                        ColorPicker::make('color'),
+                    ]),
+            ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                ColorColumn::make('color'),
+                TextColumn::make('name')
+                    ->searchable()
+                    ->sortable(),
+                TextColumn::make('slug')
+                    ->toggleable(),
+                TextColumn::make('posts_count')
+                    ->counts('posts')
+                    ->label('Posts'),
+            ])
+            ->actions([
+                EditAction::make(),
+                DeleteAction::make(),
+            ])
+            ->bulkActions([
+                BulkActionGroup::make([
+                    DeleteBulkAction::make(),
+                ]),
+            ]);
+    }
+
+    /**
+     * @return array<string, PageRegistration>
+     */
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListTags::route('/'),
+            'create' => Pages\CreateTag::route('/create'),
+            'edit' => Pages\EditTag::route('/{record}/edit'),
+        ];
+    }
+}

--- a/src/Filament/V5/Resources/TagResource/Pages/CreateTag.php
+++ b/src/Filament/V5/Resources/TagResource/Pages/CreateTag.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources\TagResource\Pages;
+
+use Filament\Resources\Pages\CreateRecord;
+use Kurt\Modules\Blog\Filament\V5\Resources\TagResource;
+
+class CreateTag extends CreateRecord
+{
+    protected static string $resource = TagResource::class;
+}

--- a/src/Filament/V5/Resources/TagResource/Pages/EditTag.php
+++ b/src/Filament/V5/Resources/TagResource/Pages/EditTag.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources\TagResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\DeleteAction;
+use Filament\Resources\Pages\EditRecord;
+use Kurt\Modules\Blog\Filament\V5\Resources\TagResource;
+
+class EditTag extends EditRecord
+{
+    protected static string $resource = TagResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            DeleteAction::make(),
+        ];
+    }
+}

--- a/src/Filament/V5/Resources/TagResource/Pages/ListTags.php
+++ b/src/Filament/V5/Resources/TagResource/Pages/ListTags.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Filament\V5\Resources\TagResource\Pages;
+
+use Filament\Actions\Action;
+use Filament\Actions\CreateAction;
+use Filament\Resources\Pages\ListRecords;
+use Kurt\Modules\Blog\Filament\V5\Resources\TagResource;
+
+class ListTags extends ListRecords
+{
+    protected static string $resource = TagResource::class;
+
+    /**
+     * @return array<int, Action>
+     */
+    protected function getHeaderActions(): array
+    {
+        return [
+            CreateAction::make(),
+        ];
+    }
+}

--- a/tests/Feature/Filament/V3/BlogPluginTest.php
+++ b/tests/Feature/Filament/V3/BlogPluginTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use Kurt\Modules\Blog\Filament\BlogPlugin;
+use Kurt\Modules\Blog\Filament\V3\Resources\CategoryResource;
+use Kurt\Modules\Blog\Filament\V3\Resources\CommentResource;
+use Kurt\Modules\Blog\Filament\V3\Resources\PostResource;
+use Kurt\Modules\Blog\Filament\V3\Resources\TagResource;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 3) {
+        $this->markTestSkipped('Filament v3 is not installed.');
+    }
+});
+
+it('dispatches the facade to the v3 plugin', function () {
+    expect(BlogPlugin::make())->toBeInstanceOf(Kurt\Modules\Blog\Filament\V3\BlogPlugin::class)
+        ->and(BlogPlugin::make()->getId())->toBe('kurtmodules-blog');
+});
+
+it('registers all four blog resources on the panel', function () {
+    $resources = Filament::getPanel('admin')->getResources();
+
+    expect($resources)
+        ->toContain(PostResource::class)
+        ->toContain(CategoryResource::class)
+        ->toContain(TagResource::class)
+        ->toContain(CommentResource::class);
+});
+
+it('registers routes for every resource', function () {
+    $uris = collect(app('router')->getRoutes()->getRoutes())
+        ->map(fn ($route) => $route->uri())
+        ->all();
+
+    expect($uris)
+        ->toContain('admin/posts', 'admin/posts/create', 'admin/posts/{record}/edit')
+        ->toContain('admin/categories', 'admin/tags')
+        ->toContain('admin/comments', 'admin/comments/{record}/edit');
+});

--- a/tests/Feature/Filament/V3/CategoryResourceTest.php
+++ b/tests/Feature/Filament/V3/CategoryResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Filament\V3\Resources\CategoryResource;
+use Kurt\Modules\Blog\Filament\V3\Resources\CategoryResource\Pages\CreateCategory;
+use Kurt\Modules\Blog\Filament\V3\Resources\CategoryResource\Pages\ListCategories;
+use Kurt\Modules\Blog\Models\Category;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 3) {
+        $this->markTestSkipped('Filament v3 is not installed.');
+    }
+});
+
+it('targets the Category model and registers its pages', function () {
+    expect(CategoryResource::getModel())->toBe(Category::class)
+        ->and(array_keys(CategoryResource::getPages()))->toBe(['index', 'create', 'edit']);
+});
+
+it('builds a translatable form with parent and slug fields', function () {
+    $fields = formFieldNames(CategoryResource::class, CreateCategory::class);
+
+    expect($fields)
+        ->toContain('name.en', 'name.tr')
+        ->toContain('description.en', 'description.tr')
+        ->toContain('parent_id', 'slug', 'position');
+});
+
+it('builds a tree-aware table', function () {
+    expect(tableColumnNames(CategoryResource::class, ListCategories::class))
+        ->toContain('name', 'parent.name', 'posts_count', 'position');
+});

--- a/tests/Feature/Filament/V3/CommentResourceTest.php
+++ b/tests/Feature/Filament/V3/CommentResourceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Tables\Table;
+use Kurt\Modules\Blog\Enums\CommentApproval;
+use Kurt\Modules\Blog\Filament\V3\Resources\CommentResource;
+use Kurt\Modules\Blog\Filament\V3\Resources\CommentResource\Pages\ListComments;
+use Kurt\Modules\Blog\Models\Comment;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 3) {
+        $this->markTestSkipped('Filament v3 is not installed.');
+    }
+});
+
+it('targets the Comment model and registers a list + edit page (no create)', function () {
+    expect(CommentResource::getModel())->toBe(Comment::class)
+        ->and(array_keys(CommentResource::getPages()))->toBe(['index', 'edit']);
+});
+
+it('builds a body + approval form', function () {
+    $fields = formFieldNames(CommentResource::class, ListComments::class);
+
+    expect($fields)->toContain('body', 'approval');
+});
+
+it('defaults the moderation queue to pending comments', function () {
+    expect(tableFilterNames(CommentResource::class, ListComments::class))
+        ->toContain('approval');
+
+    $table = CommentResource::table(Table::make(app(ListComments::class)));
+    $filter = $table->getFilters()['approval'];
+
+    expect($filter->getDefaultState())->toBe(CommentApproval::Pending->value);
+});
+
+it('offers approve/reject row actions and approve/reject/delete bulk actions', function () {
+    expect(tableActionNames(CommentResource::class, ListComments::class))
+        ->toContain('approve', 'reject', 'edit', 'delete');
+
+    expect(tableBulkActionNames(CommentResource::class, ListComments::class))
+        ->toContain('approve', 'reject', 'delete');
+});

--- a/tests/Feature/Filament/V3/PostResourceTest.php
+++ b/tests/Feature/Filament/V3/PostResourceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Filament\V3\Resources\PostResource;
+use Kurt\Modules\Blog\Filament\V3\Resources\PostResource\Pages\CreatePost;
+use Kurt\Modules\Blog\Filament\V3\Resources\PostResource\Pages\ListPosts;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 3) {
+        $this->markTestSkipped('Filament v3 is not installed.');
+    }
+});
+
+it('targets the Post model and registers its pages', function () {
+    expect(PostResource::getModel())->toBe(Post::class)
+        ->and(array_keys(PostResource::getPages()))->toBe(['index', 'create', 'edit']);
+});
+
+it('builds a translatable form with enum, conditional and media fields', function () {
+    $fields = formFieldNames(PostResource::class, CreatePost::class);
+
+    expect($fields)
+        ->toContain('title.en', 'title.tr')
+        ->toContain('excerpt.en', 'excerpt.tr')
+        ->toContain('body.en', 'body.tr')
+        ->toContain('meta_title.en', 'meta_title.tr')
+        ->toContain('meta_description.en', 'meta_description.tr')
+        ->toContain('status', 'type', 'category_id', 'tags')
+        ->toContain('scheduled_for', 'video_url')
+        ->toContain('cover');
+});
+
+it('builds a table with key columns and status/type filters', function () {
+    expect(tableColumnNames(PostResource::class, ListPosts::class))
+        ->toContain('title', 'status', 'type', 'author.name', 'category.name', 'published_at', 'view_count');
+
+    expect(tableFilterNames(PostResource::class, ListPosts::class))
+        ->toContain('status', 'type');
+});
+
+it('exposes edit, delete and bulk delete actions', function () {
+    expect(tableActionNames(PostResource::class, ListPosts::class))
+        ->toContain('edit', 'delete');
+
+    expect(tableBulkActionNames(PostResource::class, ListPosts::class))
+        ->toContain('delete');
+});

--- a/tests/Feature/Filament/V3/TagResourceTest.php
+++ b/tests/Feature/Filament/V3/TagResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Filament\V3\Resources\TagResource;
+use Kurt\Modules\Blog\Filament\V3\Resources\TagResource\Pages\CreateTag;
+use Kurt\Modules\Blog\Filament\V3\Resources\TagResource\Pages\ListTags;
+use Kurt\Modules\Blog\Models\Tag;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 3) {
+        $this->markTestSkipped('Filament v3 is not installed.');
+    }
+});
+
+it('targets the Tag model and registers its pages', function () {
+    expect(TagResource::getModel())->toBe(Tag::class)
+        ->and(array_keys(TagResource::getPages()))->toBe(['index', 'create', 'edit']);
+});
+
+it('builds a translatable form with a color picker', function () {
+    $fields = formFieldNames(TagResource::class, CreateTag::class);
+
+    expect($fields)
+        ->toContain('name.en', 'name.tr')
+        ->toContain('description.en', 'description.tr')
+        ->toContain('color');
+});
+
+it('builds a table with a color swatch column', function () {
+    expect(tableColumnNames(TagResource::class, ListTags::class))
+        ->toContain('color', 'name', 'posts_count');
+});

--- a/tests/Feature/Filament/V4/BlogPluginTest.php
+++ b/tests/Feature/Filament/V4/BlogPluginTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use Kurt\Modules\Blog\Filament\BlogPlugin;
+use Kurt\Modules\Blog\Filament\V4\Resources\CategoryResource;
+use Kurt\Modules\Blog\Filament\V4\Resources\CommentResource;
+use Kurt\Modules\Blog\Filament\V4\Resources\PostResource;
+use Kurt\Modules\Blog\Filament\V4\Resources\TagResource;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 4) {
+        $this->markTestSkipped('Filament v4 is not installed.');
+    }
+});
+
+it('dispatches the facade to the v4 plugin', function () {
+    expect(BlogPlugin::make())->toBeInstanceOf(Kurt\Modules\Blog\Filament\V4\BlogPlugin::class)
+        ->and(BlogPlugin::make()->getId())->toBe('kurtmodules-blog');
+});
+
+it('registers all four blog resources on the panel', function () {
+    $resources = Filament::getPanel('admin')->getResources();
+
+    expect($resources)
+        ->toContain(PostResource::class)
+        ->toContain(CategoryResource::class)
+        ->toContain(TagResource::class)
+        ->toContain(CommentResource::class);
+});
+
+it('registers routes for every resource', function () {
+    $uris = collect(app('router')->getRoutes()->getRoutes())
+        ->map(fn ($route) => $route->uri())
+        ->all();
+
+    expect($uris)
+        ->toContain('admin/posts', 'admin/posts/create', 'admin/posts/{record}/edit')
+        ->toContain('admin/categories', 'admin/tags')
+        ->toContain('admin/comments', 'admin/comments/{record}/edit');
+});

--- a/tests/Feature/Filament/V4/CategoryResourceTest.php
+++ b/tests/Feature/Filament/V4/CategoryResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Filament\V4\Resources\CategoryResource;
+use Kurt\Modules\Blog\Filament\V4\Resources\CategoryResource\Pages\CreateCategory;
+use Kurt\Modules\Blog\Filament\V4\Resources\CategoryResource\Pages\ListCategories;
+use Kurt\Modules\Blog\Models\Category;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 4) {
+        $this->markTestSkipped('Filament v4 is not installed.');
+    }
+});
+
+it('targets the Category model and registers its pages', function () {
+    expect(CategoryResource::getModel())->toBe(Category::class)
+        ->and(array_keys(CategoryResource::getPages()))->toBe(['index', 'create', 'edit']);
+});
+
+it('builds a translatable form with parent and slug fields', function () {
+    $fields = formFieldNames(CategoryResource::class, CreateCategory::class);
+
+    expect($fields)
+        ->toContain('name.en', 'name.tr')
+        ->toContain('description.en', 'description.tr')
+        ->toContain('parent_id', 'slug', 'position');
+});
+
+it('builds a tree-aware table', function () {
+    expect(tableColumnNames(CategoryResource::class, ListCategories::class))
+        ->toContain('name', 'parent.name', 'posts_count', 'position');
+});

--- a/tests/Feature/Filament/V4/CommentResourceTest.php
+++ b/tests/Feature/Filament/V4/CommentResourceTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Tables\Table;
+use Kurt\Modules\Blog\Enums\CommentApproval;
+use Kurt\Modules\Blog\Filament\V4\Resources\CommentResource;
+use Kurt\Modules\Blog\Filament\V4\Resources\CommentResource\Pages\ListComments;
+use Kurt\Modules\Blog\Models\Comment;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 4) {
+        $this->markTestSkipped('Filament v4 is not installed.');
+    }
+});
+
+it('targets the Comment model and registers a list + edit page (no create)', function () {
+    expect(CommentResource::getModel())->toBe(Comment::class)
+        ->and(array_keys(CommentResource::getPages()))->toBe(['index', 'edit']);
+});
+
+it('builds a body + approval form', function () {
+    $fields = formFieldNames(CommentResource::class, ListComments::class);
+
+    expect($fields)->toContain('body', 'approval');
+});
+
+it('defaults the moderation queue to pending comments', function () {
+    expect(tableFilterNames(CommentResource::class, ListComments::class))
+        ->toContain('approval');
+
+    $table = CommentResource::table(Table::make(app(ListComments::class)));
+    $filter = $table->getFilters()['approval'];
+
+    expect($filter->getDefaultState())->toBe(CommentApproval::Pending->value);
+});
+
+it('offers approve/reject row actions and approve/reject/delete bulk actions', function () {
+    expect(tableActionNames(CommentResource::class, ListComments::class))
+        ->toContain('approve', 'reject', 'edit', 'delete');
+
+    expect(tableBulkActionNames(CommentResource::class, ListComments::class))
+        ->toContain('approve', 'reject', 'delete');
+});

--- a/tests/Feature/Filament/V4/PostResourceTest.php
+++ b/tests/Feature/Filament/V4/PostResourceTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Filament\V4\Resources\PostResource;
+use Kurt\Modules\Blog\Filament\V4\Resources\PostResource\Pages\CreatePost;
+use Kurt\Modules\Blog\Filament\V4\Resources\PostResource\Pages\ListPosts;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 4) {
+        $this->markTestSkipped('Filament v4 is not installed.');
+    }
+});
+
+it('targets the Post model and registers its pages', function () {
+    expect(PostResource::getModel())->toBe(Post::class)
+        ->and(array_keys(PostResource::getPages()))->toBe(['index', 'create', 'edit']);
+});
+
+it('builds a translatable form with enum, conditional and media fields', function () {
+    $fields = formFieldNames(PostResource::class, CreatePost::class);
+
+    expect($fields)
+        ->toContain('title.en', 'title.tr')
+        ->toContain('excerpt.en', 'excerpt.tr')
+        ->toContain('body.en', 'body.tr')
+        ->toContain('meta_title.en', 'meta_title.tr')
+        ->toContain('meta_description.en', 'meta_description.tr')
+        ->toContain('status', 'type', 'category_id', 'tags')
+        ->toContain('scheduled_for', 'video_url')
+        ->toContain('cover');
+});
+
+it('builds a table with key columns and status/type filters', function () {
+    expect(tableColumnNames(PostResource::class, ListPosts::class))
+        ->toContain('title', 'status', 'type', 'author.name', 'category.name', 'published_at', 'view_count');
+
+    expect(tableFilterNames(PostResource::class, ListPosts::class))
+        ->toContain('status', 'type');
+});
+
+it('exposes edit, delete and bulk delete actions', function () {
+    expect(tableActionNames(PostResource::class, ListPosts::class))
+        ->toContain('edit', 'delete');
+
+    expect(tableBulkActionNames(PostResource::class, ListPosts::class))
+        ->toContain('delete');
+});

--- a/tests/Feature/Filament/V4/TagResourceTest.php
+++ b/tests/Feature/Filament/V4/TagResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Filament\V4\Resources\TagResource;
+use Kurt\Modules\Blog\Filament\V4\Resources\TagResource\Pages\CreateTag;
+use Kurt\Modules\Blog\Filament\V4\Resources\TagResource\Pages\ListTags;
+use Kurt\Modules\Blog\Models\Tag;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 4) {
+        $this->markTestSkipped('Filament v4 is not installed.');
+    }
+});
+
+it('targets the Tag model and registers its pages', function () {
+    expect(TagResource::getModel())->toBe(Tag::class)
+        ->and(array_keys(TagResource::getPages()))->toBe(['index', 'create', 'edit']);
+});
+
+it('builds a translatable form with a color picker', function () {
+    $fields = formFieldNames(TagResource::class, CreateTag::class);
+
+    expect($fields)
+        ->toContain('name.en', 'name.tr')
+        ->toContain('description.en', 'description.tr')
+        ->toContain('color');
+});
+
+it('builds a table with a color swatch column', function () {
+    expect(tableColumnNames(TagResource::class, ListTags::class))
+        ->toContain('color', 'name', 'posts_count');
+});

--- a/tests/Feature/Filament/V5/BlogPluginTest.php
+++ b/tests/Feature/Filament/V5/BlogPluginTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Facades\Filament;
+use Kurt\Modules\Blog\Filament\BlogPlugin;
+use Kurt\Modules\Blog\Filament\V5\Resources\CategoryResource;
+use Kurt\Modules\Blog\Filament\V5\Resources\CommentResource;
+use Kurt\Modules\Blog\Filament\V5\Resources\PostResource;
+use Kurt\Modules\Blog\Filament\V5\Resources\TagResource;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 5) {
+        $this->markTestSkipped('Filament v5 is not installed.');
+    }
+});
+
+it('dispatches the facade to the v5 plugin', function () {
+    expect(BlogPlugin::make())->toBeInstanceOf(Kurt\Modules\Blog\Filament\V5\BlogPlugin::class)
+        ->and(BlogPlugin::make()->getId())->toBe('kurtmodules-blog');
+});
+
+it('registers all four blog resources on the panel', function () {
+    $resources = Filament::getPanel('admin')->getResources();
+
+    expect($resources)
+        ->toContain(PostResource::class)
+        ->toContain(CategoryResource::class)
+        ->toContain(TagResource::class)
+        ->toContain(CommentResource::class);
+});
+
+it('registers routes for every resource', function () {
+    $uris = collect(app('router')->getRoutes()->getRoutes())
+        ->map(fn ($route) => $route->uri())
+        ->all();
+
+    expect($uris)
+        ->toContain('admin/posts', 'admin/posts/create', 'admin/posts/{record}/edit')
+        ->toContain('admin/categories', 'admin/tags')
+        ->toContain('admin/comments', 'admin/comments/{record}/edit');
+});

--- a/tests/Feature/Filament/V5/CategoryResourceTest.php
+++ b/tests/Feature/Filament/V5/CategoryResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Filament\V5\Resources\CategoryResource;
+use Kurt\Modules\Blog\Filament\V5\Resources\CategoryResource\Pages\CreateCategory;
+use Kurt\Modules\Blog\Filament\V5\Resources\CategoryResource\Pages\ListCategories;
+use Kurt\Modules\Blog\Models\Category;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 5) {
+        $this->markTestSkipped('Filament v5 is not installed.');
+    }
+});
+
+it('targets the Category model and registers its pages', function () {
+    expect(CategoryResource::getModel())->toBe(Category::class)
+        ->and(array_keys(CategoryResource::getPages()))->toBe(['index', 'create', 'edit']);
+});
+
+it('builds a translatable form with parent and slug fields', function () {
+    $fields = formFieldNames(CategoryResource::class, CreateCategory::class);
+
+    expect($fields)
+        ->toContain('name.en', 'name.tr')
+        ->toContain('description.en', 'description.tr')
+        ->toContain('parent_id', 'slug', 'position');
+});
+
+it('builds a tree-aware table', function () {
+    expect(tableColumnNames(CategoryResource::class, ListCategories::class))
+        ->toContain('name', 'parent.name', 'posts_count', 'position');
+});

--- a/tests/Feature/Filament/V5/CommentResourceTest.php
+++ b/tests/Feature/Filament/V5/CommentResourceTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Filament\Tables\Table;
+use Kurt\Modules\Blog\Enums\CommentApproval;
+use Kurt\Modules\Blog\Filament\V5\Resources\CommentResource;
+use Kurt\Modules\Blog\Filament\V5\Resources\CommentResource\Pages\ListComments;
+use Kurt\Modules\Blog\Models\Comment;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 5) {
+        $this->markTestSkipped('Filament v5 is not installed.');
+    }
+});
+
+it('targets the Comment model and registers a list + edit page (no create)', function () {
+    expect(CommentResource::getModel())->toBe(Comment::class)
+        ->and(array_keys(CommentResource::getPages()))->toBe(['index', 'edit']);
+});
+
+it('builds a body + approval form', function () {
+    $fields = formFieldNames(CommentResource::class, ListComments::class);
+
+    expect($fields)->toContain('body', 'approval');
+});
+
+it('defaults the moderation queue to pending comments', function () {
+    expect(tableFilterNames(CommentResource::class, ListComments::class))
+        ->toContain('approval');
+
+    // The approval filter defaults to the Pending bucket (moderation queue).
+    $table = CommentResource::table(
+        Table::make(app(ListComments::class))
+    );
+    $filter = $table->getFilters()['approval'];
+
+    expect($filter->getDefaultState())->toBe(CommentApproval::Pending->value);
+});
+
+it('offers approve/reject row actions and approve/reject/delete bulk actions', function () {
+    expect(tableActionNames(CommentResource::class, ListComments::class))
+        ->toContain('approve', 'reject', 'edit', 'delete');
+
+    expect(tableBulkActionNames(CommentResource::class, ListComments::class))
+        ->toContain('approve', 'reject', 'delete');
+});

--- a/tests/Feature/Filament/V5/PostResourceTest.php
+++ b/tests/Feature/Filament/V5/PostResourceTest.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Filament\V5\Resources\PostResource;
+use Kurt\Modules\Blog\Filament\V5\Resources\PostResource\Pages\CreatePost;
+use Kurt\Modules\Blog\Filament\V5\Resources\PostResource\Pages\ListPosts;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 5) {
+        $this->markTestSkipped('Filament v5 is not installed.');
+    }
+});
+
+it('targets the Post model and registers its pages', function () {
+    expect(PostResource::getModel())->toBe(Post::class)
+        ->and(array_keys(PostResource::getPages()))->toBe(['index', 'create', 'edit']);
+});
+
+it('builds a translatable form with enum, conditional and media fields', function () {
+    $fields = formFieldNames(PostResource::class, CreatePost::class);
+
+    // Translatable title/excerpt/body + SEO meta per locale (en, tr).
+    expect($fields)
+        ->toContain('title.en', 'title.tr')
+        ->toContain('excerpt.en', 'excerpt.tr')
+        ->toContain('body.en', 'body.tr')
+        ->toContain('meta_title.en', 'meta_title.tr')
+        ->toContain('meta_description.en', 'meta_description.tr')
+        // Enum selects + relationships.
+        ->toContain('status', 'type', 'category_id', 'tags')
+        // Conditional fields (status=scheduled, type=video).
+        ->toContain('scheduled_for', 'video_url')
+        // Spatie media library cover upload.
+        ->toContain('cover');
+});
+
+it('builds a table with key columns and status/type filters', function () {
+    expect(tableColumnNames(PostResource::class, ListPosts::class))
+        ->toContain('title', 'status', 'type', 'author.name', 'category.name', 'published_at', 'view_count');
+
+    expect(tableFilterNames(PostResource::class, ListPosts::class))
+        ->toContain('status', 'type');
+});
+
+it('exposes edit, delete and bulk delete actions', function () {
+    expect(tableActionNames(PostResource::class, ListPosts::class))
+        ->toContain('edit', 'delete');
+
+    expect(tableBulkActionNames(PostResource::class, ListPosts::class))
+        ->toContain('delete');
+});

--- a/tests/Feature/Filament/V5/TagResourceTest.php
+++ b/tests/Feature/Filament/V5/TagResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Filament\V5\Resources\TagResource;
+use Kurt\Modules\Blog\Filament\V5\Resources\TagResource\Pages\CreateTag;
+use Kurt\Modules\Blog\Filament\V5\Resources\TagResource\Pages\ListTags;
+use Kurt\Modules\Blog\Models\Tag;
+use Kurt\Modules\Core\Support\FilamentVersion;
+
+beforeEach(function () {
+    if (FilamentVersion::major() !== 5) {
+        $this->markTestSkipped('Filament v5 is not installed.');
+    }
+});
+
+it('targets the Tag model and registers its pages', function () {
+    expect(TagResource::getModel())->toBe(Tag::class)
+        ->and(array_keys(TagResource::getPages()))->toBe(['index', 'create', 'edit']);
+});
+
+it('builds a translatable form with a color picker', function () {
+    $fields = formFieldNames(TagResource::class, CreateTag::class);
+
+    expect($fields)
+        ->toContain('name.en', 'name.tr')
+        ->toContain('description.en', 'description.tr')
+        ->toContain('color');
+});
+
+it('builds a table with a color swatch column', function () {
+    expect(tableColumnNames(TagResource::class, ListTags::class))
+        ->toContain('color', 'name', 'posts_count');
+});

--- a/tests/Fixtures/AdminPanelProvider.php
+++ b/tests/Fixtures/AdminPanelProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Tests\Fixtures;
+
+use Filament\Panel;
+use Filament\PanelProvider;
+use Kurt\Modules\Blog\Filament\BlogPlugin;
+
+/**
+ * Minimal Filament panel used by the resource smoke tests. It registers the
+ * version-dispatching Blog plugin so the correct V{n} resource set is wired
+ * up for whichever Filament major is installed in the current CI matrix cell.
+ */
+final class AdminPanelProvider extends PanelProvider
+{
+    public function panel(Panel $panel): Panel
+    {
+        return $panel
+            ->id('admin')
+            ->path('admin')
+            ->default()
+            ->plugin(BlogPlugin::make());
+    }
+}

--- a/tests/Fixtures/PanelUser.php
+++ b/tests/Fixtures/PanelUser.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Tests\Fixtures;
+
+use Filament\Models\Contracts\FilamentUser;
+use Filament\Panel;
+use Illuminate\Foundation\Auth\User as Authenticatable;
+
+/**
+ * Authenticatable user for the Filament panel smoke tests. Implements
+ * FilamentUser so panel-access checks pass, and lives on the shared `users`
+ * table created by the base test case.
+ */
+final class PanelUser extends Authenticatable implements FilamentUser
+{
+    protected $table = 'users';
+
+    protected $guarded = [];
+
+    public $timestamps = false;
+
+    public function canAccessPanel(Panel $panel): bool
+    {
+        return true;
+    }
+}

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -62,6 +62,33 @@ if (! function_exists('Kurt\Modules\Blog\Tests\formFieldNames')) {
     }
 
     /**
+     * Recursively collect action names from a list that may contain
+     * ActionGroup/BulkActionGroup wrappers.
+     *
+     * @param  iterable<mixed>  $actions
+     * @return array<int, string>
+     */
+    function flattenActionNames(iterable $actions): array
+    {
+        $names = [];
+
+        foreach ($actions as $action) {
+            if (is_object($action) && method_exists($action, 'getName')) {
+                $names[] = $action->getName();
+            }
+
+            if (is_object($action) && method_exists($action, 'getActions')) {
+                $names = array_merge($names, flattenActionNames($action->getActions()));
+            }
+        }
+
+        return array_values(array_filter($names));
+    }
+
+    /**
+     * Bulk action names. v5 keeps them under getFlatBulkActions(); v4 stores
+     * them in the toolbar (getToolbarActions()).
+     *
      * @param  class-string  $resource
      * @param  class-string  $pageClass
      * @return array<int, string>
@@ -70,13 +97,17 @@ if (! function_exists('Kurt\Modules\Blog\Tests\formFieldNames')) {
     {
         $table = $resource::table(Table::make(app($pageClass)));
 
-        return array_values(array_map(
-            static fn ($action): string => $action->getName(),
-            $table->getFlatBulkActions(),
-        ));
+        if (method_exists($table, 'getFlatBulkActions')) {
+            return flattenActionNames($table->getFlatBulkActions());
+        }
+
+        return flattenActionNames($table->getToolbarActions());
     }
 
     /**
+     * Row action names. v5 keeps them under getFlatActions(); v4 stores them
+     * in getRecordActions().
+     *
      * @param  class-string  $resource
      * @param  class-string  $pageClass
      * @return array<int, string>
@@ -85,9 +116,10 @@ if (! function_exists('Kurt\Modules\Blog\Tests\formFieldNames')) {
     {
         $table = $resource::table(Table::make(app($pageClass)));
 
-        return array_values(array_map(
-            static fn ($action): string => $action->getName(),
-            $table->getFlatActions(),
-        ));
+        if (method_exists($table, 'getFlatActions')) {
+            return flattenActionNames($table->getFlatActions());
+        }
+
+        return flattenActionNames($table->getRecordActions());
     }
 }

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use Filament\Forms\Form;
 use Filament\Schemas\Schema;
 use Filament\Tables\Table;
 use Kurt\Modules\Blog\Tests\TestCase;
@@ -24,17 +25,33 @@ pest()->extend(TestCase::class)->in('Feature');
 |
 */
 
-if (! function_exists('Kurt\Modules\Blog\Tests\formFieldNames')) {
+if (! function_exists('formFilamentContainer')) {
+    /**
+     * Build the form container Filament passes to a resource's static form().
+     * v4/v5 use Filament\Schemas\Schema; v3 uses Filament\Forms\Form. Both
+     * accept the owning Livewire component and expose getFlatFields().
+     *
+     * @param  class-string  $pageClass
+     */
+    function formFilamentContainer(string $pageClass): object
+    {
+        $container = class_exists(Schema::class)
+            ? Schema::class
+            : Form::class;
+
+        return $container::make(app($pageClass));
+    }
+
     /**
      * @param  class-string  $resource  The resource class (form() is static).
-     * @param  class-string  $pageClass  A page of the resource, used as the schema container.
+     * @param  class-string  $pageClass  A page of the resource, used as the form container.
      * @return array<int, string>
      */
     function formFieldNames(string $resource, string $pageClass): array
     {
-        $schema = $resource::form(Schema::make(app($pageClass)));
+        $form = $resource::form(formFilamentContainer($pageClass));
 
-        return array_keys($schema->getFlatFields(withHidden: true));
+        return array_keys($form->getFlatFields(withHidden: true));
     }
 
     /**

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -2,6 +2,92 @@
 
 declare(strict_types=1);
 
+use Filament\Schemas\Schema;
+use Filament\Tables\Table;
 use Kurt\Modules\Blog\Tests\TestCase;
 
 pest()->extend(TestCase::class)->in('Feature');
+
+/*
+|--------------------------------------------------------------------------
+| Filament resource introspection helpers
+|--------------------------------------------------------------------------
+|
+| Full Filament page rendering does not work under orchestra/testbench with
+| the Filament v5 + Livewire v4 stack (the page Blade view loses its `$this`
+| binding because Testbench drops Livewire's boot-time render hooks). These
+| helpers let the version-guarded smoke tests assert the *structure* of a
+| resource's form and table — proving the resource classes build with the
+| correct components/columns/actions for each Filament major — without
+| rendering a Livewire page. A booted page instance is used purely as the
+| schema/table container.
+|
+*/
+
+if (! function_exists('Kurt\Modules\Blog\Tests\formFieldNames')) {
+    /**
+     * @param  class-string  $resource  The resource class (form() is static).
+     * @param  class-string  $pageClass  A page of the resource, used as the schema container.
+     * @return array<int, string>
+     */
+    function formFieldNames(string $resource, string $pageClass): array
+    {
+        $schema = $resource::form(Schema::make(app($pageClass)));
+
+        return array_keys($schema->getFlatFields(withHidden: true));
+    }
+
+    /**
+     * @param  class-string  $resource
+     * @param  class-string  $pageClass
+     * @return array<int, string>
+     */
+    function tableColumnNames(string $resource, string $pageClass): array
+    {
+        $table = $resource::table(Table::make(app($pageClass)));
+
+        return array_keys($table->getColumns());
+    }
+
+    /**
+     * @param  class-string  $resource
+     * @param  class-string  $pageClass
+     * @return array<int, string>
+     */
+    function tableFilterNames(string $resource, string $pageClass): array
+    {
+        $table = $resource::table(Table::make(app($pageClass)));
+
+        return array_keys($table->getFilters());
+    }
+
+    /**
+     * @param  class-string  $resource
+     * @param  class-string  $pageClass
+     * @return array<int, string>
+     */
+    function tableBulkActionNames(string $resource, string $pageClass): array
+    {
+        $table = $resource::table(Table::make(app($pageClass)));
+
+        return array_values(array_map(
+            static fn ($action): string => $action->getName(),
+            $table->getFlatBulkActions(),
+        ));
+    }
+
+    /**
+     * @param  class-string  $resource
+     * @param  class-string  $pageClass
+     * @return array<int, string>
+     */
+    function tableActionNames(string $resource, string $pageClass): array
+    {
+        $table = $resource::table(Table::make(app($pageClass)));
+
+        return array_values(array_map(
+            static fn ($action): string => $action->getName(),
+            $table->getFlatActions(),
+        ));
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,25 +5,53 @@ declare(strict_types=1);
 namespace Kurt\Modules\Blog\Tests;
 
 use Cviebrock\EloquentSluggable\ServiceProvider as SluggableServiceProvider;
+use Filament\Actions\ActionsServiceProvider;
+use Filament\FilamentServiceProvider;
+use Filament\Forms\FormsServiceProvider;
+use Filament\Infolists\InfolistsServiceProvider;
+use Filament\Notifications\NotificationsServiceProvider;
+use Filament\Schemas\SchemasServiceProvider;
+use Filament\Support\SupportServiceProvider;
+use Filament\Tables\TablesServiceProvider;
+use Filament\Widgets\WidgetsServiceProvider;
 use Illuminate\Foundation\Application;
 use Kurt\Modules\Blog\Providers\BlogServiceProvider;
+use Kurt\Modules\Blog\Tests\Fixtures\AdminPanelProvider;
 use Kurt\Modules\Core\Providers\CoreServiceProvider;
+use Kurt\Modules\Core\Support\FilamentVersion;
 use Kurt\Modules\Core\Testing\PackageTestCase;
+use Livewire\LivewireServiceProvider;
 use Spatie\MediaLibrary\MediaLibraryServiceProvider;
 
 abstract class TestCase extends PackageTestCase
 {
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Under Testbench the Livewire mechanism singletons (notably the
+        // DataStore that backs each component's error bag) lose their shared
+        // container binding after the provider's initial registration, which
+        // makes every Filament/Livewire component render throw on a null error
+        // bag. Re-running the provider's register() is idempotent and restores
+        // those singletons so the panel smoke tests can render. No-op when
+        // Filament (and therefore Livewire) is not installed.
+        if (FilamentVersion::major() !== null && class_exists(LivewireServiceProvider::class)) {
+            (new LivewireServiceProvider($this->app))->register();
+        }
+    }
+
     /**
      * @param  Application  $app
      * @return array<int, class-string>
      */
     protected function modulePackageProviders($app): array
     {
-        return [
+        return array_merge([
             SluggableServiceProvider::class,
             MediaLibraryServiceProvider::class,
             BlogServiceProvider::class,
-        ];
+        ], $this->filamentProviders());
     }
 
     /**
@@ -32,12 +60,60 @@ abstract class TestCase extends PackageTestCase
      */
     protected function getPackageProviders($app): array
     {
-        return [
+        return array_merge([
             CoreServiceProvider::class,
             SluggableServiceProvider::class,
             MediaLibraryServiceProvider::class,
             BlogServiceProvider::class,
+        ], $this->filamentProviders());
+    }
+
+    /**
+     * Filament + Livewire providers are only registered when Filament is
+     * installed, so the non-Filament suites run without them. Each provider
+     * is filtered by class_exists so the list stays valid across the v3/v4/v5
+     * matrix (e.g. filament/schemas and filament/actions are v4/v5-only
+     * packages).
+     *
+     * @return array<int, class-string>
+     */
+    protected function filamentProviders(): array
+    {
+        if (FilamentVersion::major() === null) {
+            return [];
+        }
+
+        $candidates = [
+            LivewireServiceProvider::class,
+            SupportServiceProvider::class,
+            ActionsServiceProvider::class,
+            FormsServiceProvider::class,
+            InfolistsServiceProvider::class,
+            NotificationsServiceProvider::class,
+            SchemasServiceProvider::class,
+            TablesServiceProvider::class,
+            WidgetsServiceProvider::class,
+            FilamentServiceProvider::class,
+            AdminPanelProvider::class,
         ];
+
+        return array_values(array_filter(
+            $candidates,
+            static fn (string $provider): bool => class_exists($provider),
+        ));
+    }
+
+    /**
+     * @param  Application  $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        parent::defineEnvironment($app);
+
+        // Filament's Livewire components need a session + app key so the
+        // validation error bag and CSRF are available during component tests.
+        $app['config']->set('app.key', 'base64:'.base64_encode(random_bytes(32)));
+        $app['config']->set('session.driver', 'array');
     }
 
     protected function defineDatabaseMigrations(): void


### PR DESCRIPTION
Ships the Filament admin for `ozankurt/laravel-modules-blog` across **Filament v3, v4, and v5 in parallel** — the pilot that proves the cross-version pattern for the whole KurtModules family.

## What's here

- **Three parallel resource sets** under `src/Filament/V{3,4,5}/`: `PostResource`, `CategoryResource`, `TagResource`, `CommentResource` (+ their Pages), each using its major's exact namespaces/APIs:
  - v5: `Schemas\Schema` form, `Actions\*`, table `->actions()`/`->bulkActions()`.
  - v4: `Schemas\Schema` form, `Actions\*`, table `->recordActions()`/`->toolbarActions()`.
  - v3: `Forms\Form` form + `Forms\Components\*` layout + `Forms\Get`, split `Tables\Actions\*` (table) / `Actions\*` (page), string heroicons.
- **Version-dispatching facade** `Kurt\Modules\Blog\Filament\BlogPlugin` — consumers register `->plugin(BlogPlugin::make())`; the matching V{n} plugin is resolved from `FilamentVersion::major()`.
- **Per-version PHPStan**: base `phpstan.neon` excludes the three version dirs + the facade; `phpstan-filament-v{3,4,5}.neon` each analyse exactly one dir.
- **Guarded smoke tests** under `tests/Feature/Filament/V{3,4,5}/` (skip unless the installed major matches) asserting facade dispatch, panel + route registration, and each resource's form/table structure.
- **CI matrix Filament axis** (`3.*`/`4.*`/`5.*`) with a per-major PHPStan step.
- README "Filament admin" section + CHANGELOG `[2.1.0]`.

## Feature set (all three versions, feature-equivalent)

- Post: per-locale (en/tr) translatable title/excerpt/body + SEO meta; status/type enum selects; conditional `scheduled_for` (status=scheduled) and `video_url` (type=video); category + tags relationship selects; `SpatieMediaLibraryFileUpload` cover; table with status/type filters, badges, author, category, publish date, view count.
- Category: translatable name/description, parent tree select, slug read-only on edit, post counts.
- Tag: translatable name/description + colour picker/swatch.
- Comment: moderation queue defaulting to pending; approve/reject row + bulk actions calling `Comment::approve()`/`reject()`.

## Testing note (important for the fan-out)

Full Filament **page rendering** does not work under `orchestra/testbench` with the Filament v5 + **Livewire v4** stack: Testbench drops Livewire's boot-time mechanism singletons/render hooks, so a component's error bag is null and the page Blade view loses its `$this` binding (a trivial Livewire component fails to render too — it is not a defect in these resources). `tests/TestCase.php` re-runs `LivewireServiceProvider::register()` to restore the mechanism singletons, and the smoke tests assert resource **structure via Filament's static introspection** (registration, routes, form fields, table columns/filters/actions) instead of rendering Livewire pages. This still proves the cross-version plugin contract deterministically.

PHPStan for v3/v4 could not run locally (v5 is vendored) — those cells are validated by this PR's CI matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)