### PR TITLE
fix: audit round 2 (comment isolation, publish backfill, query hygiene)

### DIFF
--- a/database/migrations/2026_07_20_000001_add_view_count_index_to_blog_posts_table.php
+++ b/database/migrations/2026_07_20_000001_add_view_count_index_to_blog_posts_table.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('blog_posts', function (Blueprint $table) {
+            // scopePopular() orders by view_count; index it so "most viewed"
+            // listings do not fall back to a full-table filesort.
+            $table->index('view_count');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('blog_posts', function (Blueprint $table) {
+            $table->dropIndex(['view_count']);
+        });
+    }
+};

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -77,7 +77,9 @@ class Category extends Model
      */
     public function scopePopular(Builder $q, bool $desc = true): Builder
     {
-        return $q->withCount('posts')->orderBy('posts_count', $desc ? 'desc' : 'asc');
+        return $q
+            ->withCount(['posts' => fn ($posts) => $posts->published()])
+            ->orderBy('posts_count', $desc ? 'desc' : 'asc');
     }
 
     protected static function newFactory(): CategoryFactory

--- a/src/Models/Comment.php
+++ b/src/Models/Comment.php
@@ -45,6 +45,24 @@ class Comment extends InteractionsComment
     use HasFactory;
 
     /**
+     * Isolate Blog comments from the shared `interactions_comments` store:
+     * every query on this subclass is constrained to comments whose
+     * commentable is a Post. Without this, Comment::query(),
+     * scopeApproved()/scopePending(), and the Filament CommentResource would
+     * surface (and moderate) every other module's comments, and post() would
+     * blindly cast a foreign commentable to a Post.
+     */
+    protected static function booted(): void
+    {
+        static::addGlobalScope('blogCommentable', function (Builder $builder): void {
+            $builder->where(
+                $builder->qualifyColumn('commentable_type'),
+                (new Post)->getMorphClass(),
+            );
+        });
+    }
+
+    /**
      * Moderation fields (`status`, `approval`, `moderated_by`, `moderated_at`)
      * are deliberately NOT mass-assignable: they may only be set through the
      * approve()/reject() verbs and the CommentObserver defaults, so untrusted

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -253,7 +253,15 @@ class Post extends Model implements HasMedia
      */
     public function recordView(?string $ip = null): self
     {
+        // Disable timestamps for the duration of the increment so recording a
+        // view never bumps updated_at; otherwise read traffic would masquerade
+        // as a content edit (and defeat scopeLatest-style ordering / caching).
+        $timestamps = $this->timestamps;
+        $this->timestamps = false;
+
         $this->increment('view_count', 1, $ip === null ? [] : ['last_viewer_ip' => $ip]);
+
+        $this->timestamps = $timestamps;
 
         return $this;
     }

--- a/src/Observers/PostObserver.php
+++ b/src/Observers/PostObserver.php
@@ -13,6 +13,18 @@ use Kurt\Modules\Blog\Models\Post;
 
 final class PostObserver
 {
+    public function saving(Post $post): void
+    {
+        // Backfill the publish timestamp when a post is set Published without
+        // an explicit published_at (e.g. the manual "Published" toggle in the
+        // Filament editor). A saving hook covers every Filament version and
+        // keeps scopePublished()/PostPolicy::view() treating it as live at
+        // once instead of leaving it invisible behind a null published_at.
+        if ($post->status === PostStatus::Published && $post->published_at === null) {
+            $post->published_at = now();
+        }
+    }
+
     public function created(Post $post): void
     {
         PostCreated::dispatch($post);

--- a/src/Support/SeoMetadata.php
+++ b/src/Support/SeoMetadata.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kurt\Modules\Blog\Support;
 
+use Illuminate\Support\Str;
 use Kurt\Modules\Blog\Models\Post;
 
 final readonly class SeoMetadata
@@ -21,11 +22,14 @@ final readonly class SeoMetadata
         $title = $post->getTranslation('meta_title', $locale, false)
             ?: $post->getTranslation('title', $locale);
 
+        // Fall back to the excerpt, then the body. Strip HTML *before*
+        // truncating and use Str::limit so the cut is multibyte-safe and the
+        // 160-char budget counts visible text, not tag bytes.
+        $rawDescription = $post->getTranslation('excerpt', $locale, false)
+            ?: $post->getTranslation('body', $locale, false);
+
         $description = $post->getTranslation('meta_description', $locale, false)
-            ?: strip_tags(
-                $post->getTranslation('excerpt', $locale, false)
-                    ?: substr((string) $post->getTranslation('body', $locale, false), 0, 160)
-            );
+            ?: Str::limit(strip_tags((string) $rawDescription), 160);
 
         $ogImage = $post->meta_og_image
             ?: $post->getFirstMediaUrl('social')

--- a/tests/Feature/Models/CategoryPopularTest.php
+++ b/tests/Feature/Models/CategoryPopularTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Models\Category;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Tests\Stubs\StubUser;
+
+beforeEach(function () {
+    $this->user = StubUser::create(['email' => 'author@example.com']);
+});
+
+it('counts only published posts in scopePopular', function () {
+    $category = Category::factory()->create();
+
+    Post::factory()->count(2)->published()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $category->id,
+    ]);
+
+    // Drafts, scheduled and future-dated posts must not inflate the count.
+    Post::factory()->create(['user_id' => $this->user->id, 'category_id' => $category->id]);
+    Post::factory()->scheduled(now()->addDay())->create(['user_id' => $this->user->id, 'category_id' => $category->id]);
+
+    $popular = Category::popular()->firstOrFail();
+
+    expect($popular->posts_count)->toBe(2);
+});
+
+it('orders categories by their published post count', function () {
+    $busy = Category::factory()->create();
+    $quiet = Category::factory()->create();
+
+    Post::factory()->count(3)->published()->create(['user_id' => $this->user->id, 'category_id' => $busy->id]);
+    Post::factory()->published()->create(['user_id' => $this->user->id, 'category_id' => $quiet->id]);
+    // A pile of drafts on the "quiet" category must not push it to the top.
+    Post::factory()->count(5)->create(['user_id' => $this->user->id, 'category_id' => $quiet->id]);
+
+    $ordered = Category::popular()->pluck('id')->all();
+
+    expect($ordered)->toBe([$busy->id, $quiet->id]);
+});

--- a/tests/Feature/Models/CommentIsolationTest.php
+++ b/tests/Feature/Models/CommentIsolationTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Enums\CommentApproval;
+use Kurt\Modules\Blog\Models\Comment;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Tests\Stubs\StubUser;
+use Kurt\Modules\Interactions\Comments\Enums\CommentStatus;
+use Kurt\Modules\Interactions\Comments\Models\Comment as InteractionsComment;
+
+beforeEach(function () {
+    $this->user = StubUser::create(['email' => 'author@example.com']);
+    $this->post = Post::factory()->create(['user_id' => $this->user->id]);
+
+    // A comment attached to a non-Post commentable (another module sharing the
+    // interactions_comments store). It is Published so it would also leak
+    // through scopeApproved() if isolation were missing.
+    $this->foreign = InteractionsComment::create([
+        'user_id' => $this->user->id,
+        'commentable_type' => 'App\\Models\\ForumThread',
+        'commentable_id' => 999,
+        'body' => 'foreign comment',
+        'status' => CommentStatus::Published->value,
+    ]);
+});
+
+it('excludes non-Post comments from the Blog comment query', function () {
+    Comment::create([
+        'post_id' => $this->post->id,
+        'user_id' => $this->user->id,
+        'body' => 'blog comment',
+    ]);
+
+    expect(Comment::count())->toBe(1)
+        ->and(Comment::query()->pluck('body')->all())->toBe(['blog comment'])
+        ->and(Comment::find($this->foreign->getKey()))->toBeNull();
+});
+
+it('excludes non-Post comments from scopeApproved and scopePending', function () {
+    $approved = Comment::create([
+        'post_id' => $this->post->id,
+        'user_id' => $this->user->id,
+        'body' => 'approved blog comment',
+    ]);
+    $approved->approve($this->user);
+
+    Comment::create([
+        'post_id' => $this->post->id,
+        'user_id' => $this->user->id,
+        'body' => 'pending blog comment',
+    ]);
+
+    expect(Comment::approved()->count())->toBe(1)
+        ->and(Comment::approved()->first()->body)->toBe('approved blog comment')
+        ->and(Comment::pending()->count())->toBe(1)
+        ->and(Comment::pending()->first()->body)->toBe('pending blog comment');
+});
+
+it('keeps post() resolving to a Post because foreign commentables are scoped out', function () {
+    $comment = Comment::create([
+        'post_id' => $this->post->id,
+        'user_id' => $this->user->id,
+        'body' => 'blog comment',
+    ]);
+
+    expect($comment->approval)->toBe(CommentApproval::Pending)
+        ->and($comment->post)->toBeInstanceOf(Post::class)
+        ->and($comment->post->id)->toBe($this->post->id);
+});

--- a/tests/Feature/Models/PostPublishBackfillTest.php
+++ b/tests/Feature/Models/PostPublishBackfillTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Enums\PostStatus;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Policies\PostPolicy;
+use Kurt\Modules\Blog\Tests\Stubs\StubUser;
+
+beforeEach(function () {
+    $this->user = StubUser::create(['email' => 'author@example.com']);
+});
+
+it('backfills published_at when a post is saved Published with none set', function () {
+    $post = Post::factory()->create([
+        'user_id' => $this->user->id,
+        'status' => PostStatus::Draft,
+    ]);
+
+    expect($post->published_at)->toBeNull();
+
+    $post->status = PostStatus::Published;
+    $post->save();
+
+    expect($post->fresh()->published_at)->not->toBeNull();
+});
+
+it('makes a manually published post visible via scopePublished and PostPolicy::view', function () {
+    $post = Post::factory()->create([
+        'user_id' => $this->user->id,
+        'status' => PostStatus::Published,
+        'published_at' => null,
+    ]);
+
+    expect($post->fresh()->published_at)->not->toBeNull()
+        ->and(Post::published()->whereKey($post->id)->exists())->toBeTrue()
+        ->and((new PostPolicy)->view(null, $post->fresh()))->toBeTrue();
+});
+
+it('does not overwrite an explicit published_at', function () {
+    $when = now()->subWeek()->startOfSecond();
+
+    $post = Post::factory()->create([
+        'user_id' => $this->user->id,
+        'status' => PostStatus::Published,
+        'published_at' => $when,
+    ]);
+
+    expect($post->fresh()->published_at->equalTo($when))->toBeTrue();
+});

--- a/tests/Feature/Models/RecordViewTest.php
+++ b/tests/Feature/Models/RecordViewTest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\DB;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Tests\Stubs\StubUser;
+
+beforeEach(function () {
+    $this->user = StubUser::create(['email' => 'author@example.com']);
+});
+
+it('increments view_count without bumping updated_at', function () {
+    $post = Post::factory()->create(['user_id' => $this->user->id]);
+
+    // Pin updated_at firmly in the past so any bump would be unmistakable.
+    $past = now()->subDay()->startOfSecond();
+    DB::table('blog_posts')->where('id', $post->id)->update(['updated_at' => $past]);
+    $post->refresh();
+
+    $post->recordView('203.0.113.7');
+
+    $fresh = $post->fresh();
+
+    expect($fresh->view_count)->toBe(1)
+        ->and($fresh->last_viewer_ip)->toBe('203.0.113.7')
+        ->and($fresh->updated_at->equalTo($past))->toBeTrue();
+});

--- a/tests/Feature/Models/SeoMetadataTest.php
+++ b/tests/Feature/Models/SeoMetadataTest.php
@@ -21,6 +21,24 @@ it('returns SEO metadata using title fallback', function () {
     expect($seo->description)->toBe('Sample excerpt');
 });
 
+it('strips HTML and truncates the body multibyte-safely for the description', function () {
+    $user = StubUser::create(['email' => 'a@b.c']);
+    $body = '<p><strong>'.str_repeat('é', 300).'</strong></p>';
+    $post = Post::factory()->create([
+        'user_id' => $user->id,
+        'title' => ['en' => 'Title'],
+        'excerpt' => ['en' => ''],
+        'body' => ['en' => $body],
+    ]);
+
+    $seo = $post->seo();
+
+    expect($seo->description)
+        ->not->toContain('<')
+        ->and(mb_strlen($seo->description))->toBeLessThanOrEqual(163) // 160 chars + Str::limit's '...'
+        ->and(str_starts_with($seo->description, 'é'))->toBeTrue();
+});
+
 it('overrides via meta_title and meta_description', function () {
     $user = StubUser::create(['email' => 'a@b.c']);
     $post = Post::factory()->create([


### PR DESCRIPTION
Implements the six audit-report-#2 findings.

## Fixes
1. **[High] Comment isolation** — `Comment` now boots a global scope constraining `commentable_type` to the `Post` morph class. `Comment::query()`, `scopeApproved()/scopePending()`, and every Filament `CommentResource` (V3/V4/V5, via the default `getEloquentQuery()`) now only ever see Blog comments, and `post()` can no longer cast a foreign commentable to a `Post`. One model-level scope covers all Filament versions.
2. **[High] Manual publish backfill** — `PostObserver::saving()` sets `published_at = now()` when a post is Published with a null `published_at`. A saving hook covers all Filament versions, so manually-published posts become visible via `scopePublished()` / `PostPolicy::view()` immediately.
3. **[Med] Index `view_count`** — new migration `2026_07_20_000001_add_view_count_index_to_blog_posts_table` adds the index that `scopePopular()` orders on.
4. **[Med] Category count** — `Category::scopePopular()` scopes `posts_count` to published posts, so drafts/scheduled/archived no longer inflate it.
5. **[Med] recordView timestamps** — the view increment now runs with timestamps disabled, so a view no longer bumps `updated_at`.
6. **[Low] SEO description** — `SeoMetadata` strips HTML before a multibyte-safe `Str::limit(..., 160)`, instead of a byte `substr` on raw HTML.

## Tests
New regression tests for all six fixes, including the previously untested comment-isolation and manual-publish gaps:
- `CommentIsolationTest`, `PostPublishBackfillTest`, `CategoryPopularTest`, `RecordViewTest`, and a body-strip case added to `SeoMetadataTest`.

## Gates
- Pest: green (62 passed, 34 skipped for uninstalled Filament majors).
- PHPStan level 8: clean (base + Filament v5 config).
- Pint: clean on changed files.