### PR TITLE
feat(blog): related posts, RSS feed + sitemap headless helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
 
 ## [Unreleased]
 
+### Added
+- **Related posts** — `Post::related(int $limit = 5)` (backed by a `relatedTo`
+  scope) returns published, non-self posts ranked by shared-tag overlap and
+  then a shared category, in a single N+1-free query.
+- **RSS / feed data** — `Kurt\Modules\Blog\Support\FeedBuilder` produces a valid
+  RSS 2.0 XML string (`toRss()`) or a plain data structure (`toArray()`) for the
+  latest published posts, with configurable count and optional per-category
+  scoping. Headless: the consuming app wires it to a route.
+- **Sitemap hooks** — `Kurt\Modules\Blog\Support\SitemapBuilder` returns
+  `SitemapEntry` (loc/lastmod/changefreq/priority) rows for published posts,
+  categories with published posts, and (opt-in) tags, for the app to feed into
+  its own sitemap.
+- `feed` and `sitemap` default blocks in `config/blog.php`.
+
 ## [2.2.1] - 2026-05-31
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -24,13 +24,93 @@ php artisan migrate
 
 ## What it provides
 
-- `Kurt\Modules\Blog\Models\Post` — with translatable title/excerpt/body/meta_*, status enum (Draft/Scheduled/Published/Archived), type enum (Text/Image/Video/Carousel), scopes (`published`, `scheduled`, `drafts`, `popular`, `inCategory`, `withTags`, `authoredBy`).
+- `Kurt\Modules\Blog\Models\Post` — with translatable title/excerpt/body/meta_*, status enum (Draft/Scheduled/Published/Archived), type enum (Text/Image/Video/Carousel), scopes (`published`, `scheduled`, `drafts`, `popular`, `inCategory`, `withTags`, `authoredBy`), a `relatedTo` scope, and a `related()` helper.
 - `Category`, `Tag`, `Comment` models with their relations and scopes.
 - `BlogAuthor` contract + `IsBlogAuthor` trait for your User model.
 - `Kurt\Modules\Blog\Support\VideoUrl::parse()` for YouTube / Vimeo / DailyMotion URL parsing.
 - `Kurt\Modules\Blog\Support\SeoMetadata::forPost()` for SEO meta resolution.
+- `Kurt\Modules\Blog\Support\FeedBuilder` for RSS 2.0 / feed data, and `SitemapBuilder` for sitemap entries — see [Headless helpers](#headless-helpers).
 - Console commands: `blog:publish-due`, `blog:upgrade-translations`, `blog:demo`.
 - Domain events: `PostCreated`, `PostUpdated`, `PostPublished`, `PostArchived`, `CommentCreated`, `CommentApproved`, `CommentRejected`, ...
+
+## Related posts
+
+`$post->related(int $limit = 5)` returns published, non-self posts ranked by
+relatedness: those sharing the most tags come first, then a shared category acts
+as a fallback so lightly-tagged posts still surface neighbours. It runs as a
+single query (no N+1) — only the current post's tag ids are loaded up front, and
+the overlap count is a correlated subquery over the pivot.
+
+```php
+$related = $post->related();      // Collection<Post>, up to 5
+$related = $post->related(10);    // widen the limit
+
+// Or compose from the underlying scope (adds `shared_tags` /
+// `shared_category` ordering columns), e.g. with eager loads:
+Post::relatedTo($post)->with('category')->limit(3)->get();
+```
+
+A post with neither tags nor a category has no neighbours and yields an empty
+collection.
+
+## Headless helpers
+
+The module ships no routes or views. Feed and sitemap generation are provided as
+support classes that return a string or a data structure; your app decides where
+to expose them.
+
+### RSS / feed — `FeedBuilder`
+
+`Kurt\Modules\Blog\Support\FeedBuilder` builds the latest published posts into an
+RSS 2.0 XML string (`toRss()`) or a plain data structure (`toArray()`, for
+JSON Feed / Atom / a Blade view). Count is configurable, and the feed can be
+scoped to a category. All dynamic text is XML-escaped, so `toRss()` is always
+well-formed.
+
+```php
+use Kurt\Modules\Blog\Support\FeedBuilder;
+
+// In the consuming app's routes:
+Route::get('feed', fn () => response(
+    FeedBuilder::make()->limit(20)->toRss(),
+    200,
+    ['Content-Type' => 'application/rss+xml; charset=UTF-8'],
+));
+
+// Per-category feed, custom item URLs and channel metadata:
+FeedBuilder::make()
+    ->forCategory($category)
+    ->title('My Blog')
+    ->link(url('/'))
+    ->linkUsing(fn ($post) => route('posts.show', $post->slug))
+    ->toRss();
+```
+
+Defaults (feed title/description/limit) live under the `feed` key in
+`config/blog.php`.
+
+### Sitemap — `SitemapBuilder`
+
+`Kurt\Modules\Blog\Support\SitemapBuilder` returns `SitemapEntry` objects
+(`loc` / `lastmod` / `changefreq` / `priority`) for public content: every
+published post, every category holding at least one published post, and
+(opt-in) every tag that does. Draft, scheduled and future-dated posts — and
+categories/tags whose only posts are non-public — are excluded.
+
+```php
+use Kurt\Modules\Blog\Support\SitemapBuilder;
+
+$entries = SitemapBuilder::make()
+    ->includeTags()                                   // optional
+    ->postLinkUsing(fn ($post) => route('posts.show', $post->slug))
+    ->entries();                                      // Collection<SitemapEntry>
+
+$rows = SitemapBuilder::make()->toArray();            // array of loc/lastmod/... rows
+```
+
+Feed the entries into whichever sitemap package or response your app already
+uses. Per-type change frequencies live under the `sitemap` key in
+`config/blog.php`.
 
 ## Filament admin
 

--- a/config/blog.php
+++ b/config/blog.php
@@ -41,4 +41,22 @@ return [
     ],
 
     'route_prefix' => 'blog',
+
+    // FeedBuilder defaults. `title`/`description` fall back to the app name and
+    // a generic label when null; `limit` caps how many latest posts a feed
+    // carries. All are overridable per feed via the builder's fluent setters.
+    'feed' => [
+        'title' => null,
+        'description' => 'Latest posts',
+        'limit' => 20,
+    ],
+
+    // SitemapBuilder per-type change frequencies.
+    'sitemap' => [
+        'changefreq' => [
+            'posts' => 'weekly',
+            'categories' => 'daily',
+            'tags' => 'weekly',
+        ],
+    ],
 ];

--- a/src/Models/Category.php
+++ b/src/Models/Category.php
@@ -12,6 +12,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Spatie\Translatable\HasTranslations;
 
 /**
@@ -21,6 +22,8 @@ use Spatie\Translatable\HasTranslations;
  * @property string|null $description
  * @property int|null $parent_id
  * @property int $position
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  */
 class Category extends Model
 {

--- a/src/Models/Post.php
+++ b/src/Models/Post.php
@@ -7,6 +7,7 @@ namespace Kurt\Modules\Blog\Models;
 use Cviebrock\EloquentSluggable\Sluggable;
 use Database\Factories\Kurt\Modules\Blog\PostFactory;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -14,6 +15,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\MorphMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
 use Kurt\Modules\Blog\Enums\PostStatus;
 use Kurt\Modules\Blog\Enums\PostType;
 use Kurt\Modules\Blog\Support\SeoMetadata;
@@ -44,6 +46,8 @@ use Spatie\Translatable\HasTranslations;
  * @property string|null $meta_title
  * @property string|null $meta_description
  * @property string|null $meta_og_image
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  */
 class Post extends Model implements HasMedia
 {
@@ -235,6 +239,82 @@ class Post extends Model implements HasMedia
     public function scopeAuthoredBy(Builder $q, Model|int $user): Builder
     {
         return $q->where('user_id', $user instanceof Model ? $user->getKey() : $user);
+    }
+
+    /**
+     * Rank published, non-self posts by relatedness to $post: posts that share
+     * the most tags come first, then a shared category acts as a fallback so
+     * loosely-tagged posts still surface neighbours. The scope emits two
+     * computed columns, `shared_tags` and `shared_category`, used only for
+     * ordering. It runs as a single query (no N+1): the current post's tag ids
+     * are the only thing loaded up front, and the overlap count is a correlated
+     * subquery over the pivot rather than a per-candidate lookup.
+     *
+     * @param  Builder<self>  $q
+     * @return Builder<self>
+     */
+    public function scopeRelatedTo(Builder $q, self $post): Builder
+    {
+        $tagIds = $post->tags()->pluck('blog_tags.id')->all();
+        $categoryId = $post->category_id;
+
+        $q->select('blog_posts.*')
+            ->published()
+            ->whereKeyNot($post->getKey());
+
+        // A post with neither tags nor a category has nothing to relate to;
+        // short-circuit to an empty result rather than returning random posts.
+        if ($tagIds === [] && $categoryId === null) {
+            return $q->whereRaw('1 = 0')
+                ->selectRaw('0 as shared_tags')
+                ->selectRaw('0 as shared_category');
+        }
+
+        // shared_tags: how many of $post's tags each candidate also carries.
+        if ($tagIds === []) {
+            $q->selectRaw('0 as shared_tags');
+        } else {
+            $q->selectSub(
+                DB::table('blog_post_tag')
+                    ->selectRaw('count(*)')
+                    ->whereColumn('blog_post_tag.post_id', 'blog_posts.id')
+                    ->whereIn('blog_post_tag.tag_id', $tagIds),
+                'shared_tags',
+            );
+        }
+
+        // shared_category: 1 when the candidate sits in $post's category, else 0.
+        $q->selectRaw('case when blog_posts.category_id = ? then 1 else 0 end as shared_category', [$categoryId]);
+
+        // Restrict to genuine neighbours: a candidate must share at least one
+        // tag or the category, otherwise it is not related and would only pad
+        // the list.
+        $q->where(function (Builder $w) use ($tagIds, $categoryId): void {
+            if ($tagIds !== []) {
+                $w->whereHas('tags', fn (Builder $t) => $t->whereIn('blog_tags.id', $tagIds));
+            }
+
+            if ($categoryId !== null) {
+                $w->orWhere('blog_posts.category_id', $categoryId);
+            }
+        });
+
+        return $q
+            ->orderByDesc('shared_tags')
+            ->orderByDesc('shared_category')
+            ->orderByDesc('published_at')
+            ->orderByDesc('id');
+    }
+
+    /**
+     * Published, non-self posts most related to this one: shared tags first,
+     * then a shared category, newest as the final tiebreaker.
+     *
+     * @return Collection<int, self>
+     */
+    public function related(int $limit = 5): Collection
+    {
+        return static::relatedTo($this)->limit(max(1, $limit))->get();
     }
 
     public function videoSource(): ?VideoSource

--- a/src/Models/Tag.php
+++ b/src/Models/Tag.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
+use Illuminate\Support\Carbon;
 use Spatie\Translatable\HasTranslations;
 
 /**
@@ -18,6 +19,8 @@ use Spatie\Translatable\HasTranslations;
  * @property string $name
  * @property string|null $description
  * @property string|null $color
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
  */
 class Tag extends Model
 {

--- a/src/Support/FeedBuilder.php
+++ b/src/Support/FeedBuilder.php
@@ -1,0 +1,242 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Support;
+
+use Closure;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Str;
+use Kurt\Modules\Blog\Models\Category;
+use Kurt\Modules\Blog\Models\Post;
+
+/**
+ * Builds feed data for the latest published posts. Headless by design: it
+ * returns a data structure (toArray) or a ready-to-serve RSS 2.0 XML string
+ * (toRss); a consuming app decides where to expose it, e.g.
+ *
+ *     Route::get('feed', fn () => response(
+ *         FeedBuilder::make()->toRss(),
+ *         200,
+ *         ['Content-Type' => 'application/rss+xml; charset=UTF-8'],
+ *     ));
+ */
+final class FeedBuilder
+{
+    private int $limit;
+
+    private ?Category $category = null;
+
+    private ?string $title = null;
+
+    private ?string $description = null;
+
+    private ?string $link = null;
+
+    private ?Closure $linkResolver = null;
+
+    public function __construct()
+    {
+        $this->limit = max(1, (int) config('blog.feed.limit', 20));
+    }
+
+    public static function make(): self
+    {
+        return new self;
+    }
+
+    public function limit(int $limit): self
+    {
+        $this->limit = max(1, $limit);
+
+        return $this;
+    }
+
+    public function forCategory(Category|int $category): self
+    {
+        $this->category = $category instanceof Category
+            ? $category
+            : Category::query()->findOrFail($category);
+
+        return $this;
+    }
+
+    public function title(string $title): self
+    {
+        $this->title = $title;
+
+        return $this;
+    }
+
+    public function description(string $description): self
+    {
+        $this->description = $description;
+
+        return $this;
+    }
+
+    public function link(string $link): self
+    {
+        $this->link = $link;
+
+        return $this;
+    }
+
+    /**
+     * Override how a post's canonical URL is resolved. The callback receives
+     * the Post and must return a string URL. Defaults to
+     * `url({route_prefix}/{slug})`.
+     */
+    public function linkUsing(Closure $resolver): self
+    {
+        $this->linkResolver = $resolver;
+
+        return $this;
+    }
+
+    /**
+     * The published posts backing the feed, newest first. Category is eager
+     * loaded so rendering item `<category>` never triggers an N+1.
+     *
+     * @return Collection<int, Post>
+     */
+    public function posts(): Collection
+    {
+        $query = Post::query()
+            ->with('category')
+            ->published();
+
+        if ($this->category !== null) {
+            $query->inCategory($this->category);
+        }
+
+        return $query
+            ->orderByDesc('published_at')
+            ->orderByDesc('id')
+            ->limit($this->limit)
+            ->get();
+    }
+
+    /**
+     * The feed as a plain data structure, for consumers that render their own
+     * format (JSON Feed, Atom, a Blade view, ...).
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        $posts = $this->posts();
+        $latest = $posts->first();
+
+        return [
+            'title' => $this->resolvedTitle(),
+            'link' => $this->resolvedLink(),
+            'description' => $this->resolvedDescription(),
+            'updated' => $latest?->published_at?->toAtomString(),
+            'items' => $posts->map(fn (Post $post): array => [
+                'title' => (string) $post->title,
+                'link' => $this->linkFor($post),
+                'guid' => $this->linkFor($post),
+                'summary' => $this->summaryFor($post),
+                'category' => $post->category?->name,
+                'published_at' => $post->published_at?->toAtomString(),
+            ])->all(),
+        ];
+    }
+
+    /**
+     * A valid RSS 2.0 document for the resolved posts. All dynamic text is
+     * XML-escaped, so the output is always well-formed.
+     */
+    public function toRss(): string
+    {
+        $posts = $this->posts();
+
+        $lastBuild = '';
+        $latest = $posts->first();
+        if ($latest instanceof Post && $latest->published_at instanceof Carbon) {
+            $lastBuild = '<lastBuildDate>'.$this->esc($latest->published_at->toRssString()).'</lastBuildDate>';
+        }
+
+        $items = $posts->map(fn (Post $post): string => $this->renderItem($post))->implode('');
+
+        return '<?xml version="1.0" encoding="UTF-8"?>'
+            .'<rss version="2.0"><channel>'
+            .'<title>'.$this->esc($this->resolvedTitle()).'</title>'
+            .'<link>'.$this->esc($this->resolvedLink()).'</link>'
+            .'<description>'.$this->esc($this->resolvedDescription()).'</description>'
+            .$lastBuild
+            .$items
+            .'</channel></rss>';
+    }
+
+    private function renderItem(Post $post): string
+    {
+        $link = $this->linkFor($post);
+
+        $parts = [
+            '<title>'.$this->esc((string) $post->title).'</title>',
+            '<link>'.$this->esc($link).'</link>',
+            '<guid isPermaLink="true">'.$this->esc($link).'</guid>',
+            '<description>'.$this->esc($this->summaryFor($post)).'</description>',
+        ];
+
+        if ($post->category !== null) {
+            $parts[] = '<category>'.$this->esc((string) $post->category->name).'</category>';
+        }
+
+        if ($post->published_at instanceof Carbon) {
+            $parts[] = '<pubDate>'.$this->esc($post->published_at->toRssString()).'</pubDate>';
+        }
+
+        return '<item>'.implode('', $parts).'</item>';
+    }
+
+    private function summaryFor(Post $post): string
+    {
+        $excerpt = trim((string) $post->excerpt);
+
+        if ($excerpt !== '') {
+            return $excerpt;
+        }
+
+        return Str::limit(strip_tags((string) $post->body), 280);
+    }
+
+    private function linkFor(Post $post): string
+    {
+        if ($this->linkResolver !== null) {
+            return (string) ($this->linkResolver)($post);
+        }
+
+        return url($this->prefix().'/'.$post->slug);
+    }
+
+    private function resolvedTitle(): string
+    {
+        return $this->title
+            ?? (string) config('blog.feed.title', config('app.name', 'Blog'));
+    }
+
+    private function resolvedDescription(): string
+    {
+        return $this->description
+            ?? (string) config('blog.feed.description', 'Latest posts');
+    }
+
+    private function resolvedLink(): string
+    {
+        return $this->link ?? url($this->prefix());
+    }
+
+    private function prefix(): string
+    {
+        return trim((string) config('blog.route_prefix', 'blog'), '/');
+    }
+
+    private function esc(string $value): string
+    {
+        return htmlspecialchars($value, ENT_XML1 | ENT_QUOTES, 'UTF-8');
+    }
+}

--- a/src/Support/SitemapBuilder.php
+++ b/src/Support/SitemapBuilder.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Support;
+
+use Closure;
+use Illuminate\Support\Collection;
+use Kurt\Modules\Blog\Models\Category;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Models\Tag;
+
+/**
+ * Produces sitemap entries for the blog's public content: every published
+ * post, every category that holds at least one published post, and (opt-in)
+ * every tag that does. Draft, scheduled and future-dated posts are excluded,
+ * as are categories and tags whose only posts are non-public. Headless by
+ * design: it returns the entries for a consuming app to merge into its own
+ * sitemap.
+ */
+final class SitemapBuilder
+{
+    private bool $includeTags = false;
+
+    private ?Closure $postLink = null;
+
+    private ?Closure $categoryLink = null;
+
+    private ?Closure $tagLink = null;
+
+    public static function make(): self
+    {
+        return new self;
+    }
+
+    public function includeTags(bool $include = true): self
+    {
+        $this->includeTags = $include;
+
+        return $this;
+    }
+
+    /**
+     * Override how a post's URL is resolved. The callback receives the Post and
+     * returns a string URL. Defaults to `url({route_prefix}/{slug})`.
+     */
+    public function postLinkUsing(Closure $resolver): self
+    {
+        $this->postLink = $resolver;
+
+        return $this;
+    }
+
+    public function categoryLinkUsing(Closure $resolver): self
+    {
+        $this->categoryLink = $resolver;
+
+        return $this;
+    }
+
+    public function tagLinkUsing(Closure $resolver): self
+    {
+        $this->tagLink = $resolver;
+
+        return $this;
+    }
+
+    /**
+     * @return Collection<int, SitemapEntry>
+     */
+    public function entries(): Collection
+    {
+        return new Collection([
+            ...$this->postEntries(),
+            ...$this->categoryEntries(),
+            ...($this->includeTags ? $this->tagEntries() : []),
+        ]);
+    }
+
+    /**
+     * The entries as plain arrays, ready to serialize.
+     *
+     * @return array<int, array<string, string>>
+     */
+    public function toArray(): array
+    {
+        return $this->entries()
+            ->map(static fn (SitemapEntry $entry): array => $entry->toArray())
+            ->all();
+    }
+
+    /**
+     * @return array<int, SitemapEntry>
+     */
+    private function postEntries(): array
+    {
+        return Post::query()
+            ->published()
+            ->orderByDesc('published_at')
+            ->get()
+            ->map(fn (Post $post): SitemapEntry => new SitemapEntry(
+                loc: $this->postLoc($post),
+                lastmod: $post->updated_at,
+                changefreq: (string) config('blog.sitemap.changefreq.posts', 'weekly'),
+                priority: 0.7,
+            ))
+            ->all();
+    }
+
+    /**
+     * @return array<int, SitemapEntry>
+     */
+    private function categoryEntries(): array
+    {
+        // Categories that hold at least one published post. Derived from the
+        // Post `published` scope (rather than a whereHas on the Category side)
+        // so the definition of "public" stays in one place.
+        $categoryIds = Post::query()
+            ->published()
+            ->whereNotNull('category_id')
+            ->distinct()
+            ->pluck('category_id');
+
+        return Category::query()
+            ->whereIn('id', $categoryIds)
+            ->get()
+            ->map(fn (Category $category): SitemapEntry => new SitemapEntry(
+                loc: $this->categoryLoc($category),
+                lastmod: $category->updated_at,
+                changefreq: (string) config('blog.sitemap.changefreq.categories', 'daily'),
+                priority: 0.5,
+            ))
+            ->all();
+    }
+
+    /**
+     * @return array<int, SitemapEntry>
+     */
+    private function tagEntries(): array
+    {
+        // Tags carried by at least one published post, via the pivot joined to
+        // the Post `published` scope so no publish rule is duplicated here.
+        $tagIds = Post::query()
+            ->published()
+            ->join('blog_post_tag', 'blog_post_tag.post_id', '=', 'blog_posts.id')
+            ->distinct()
+            ->pluck('blog_post_tag.tag_id');
+
+        return Tag::query()
+            ->whereIn('id', $tagIds)
+            ->get()
+            ->map(fn (Tag $tag): SitemapEntry => new SitemapEntry(
+                loc: $this->tagLoc($tag),
+                lastmod: $tag->updated_at,
+                changefreq: (string) config('blog.sitemap.changefreq.tags', 'weekly'),
+                priority: 0.3,
+            ))
+            ->all();
+    }
+
+    private function postLoc(Post $post): string
+    {
+        return $this->postLink !== null
+            ? (string) ($this->postLink)($post)
+            : url($this->prefix().'/'.$post->slug);
+    }
+
+    private function categoryLoc(Category $category): string
+    {
+        return $this->categoryLink !== null
+            ? (string) ($this->categoryLink)($category)
+            : url($this->prefix().'/category/'.$category->slug);
+    }
+
+    private function tagLoc(Tag $tag): string
+    {
+        return $this->tagLink !== null
+            ? (string) ($this->tagLink)($tag)
+            : url($this->prefix().'/tag/'.$tag->slug);
+    }
+
+    private function prefix(): string
+    {
+        return trim((string) config('blog.route_prefix', 'blog'), '/');
+    }
+}

--- a/src/Support/SitemapEntry.php
+++ b/src/Support/SitemapEntry.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Support;
+
+use Illuminate\Support\Carbon;
+
+/**
+ * A single sitemap URL entry (loc / lastmod / changefreq / priority), the
+ * shape a consuming app feeds into its own sitemap generator.
+ */
+final readonly class SitemapEntry
+{
+    public function __construct(
+        public string $loc,
+        public ?Carbon $lastmod = null,
+        public ?string $changefreq = null,
+        public ?float $priority = null,
+    ) {}
+
+    /**
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        return array_filter([
+            'loc' => $this->loc,
+            'lastmod' => $this->lastmod?->toAtomString(),
+            'changefreq' => $this->changefreq,
+            'priority' => $this->priority !== null ? number_format($this->priority, 1) : null,
+        ], static fn (?string $value): bool => $value !== null && $value !== '');
+    }
+}

--- a/tests/Feature/Models/RelatedPostsTest.php
+++ b/tests/Feature/Models/RelatedPostsTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Models\Category;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Models\Tag;
+use Kurt\Modules\Blog\Tests\Stubs\StubUser;
+
+beforeEach(function () {
+    $this->user = StubUser::create(['email' => 'author@example.com']);
+});
+
+it('ranks related posts by shared tag overlap, then shared category', function () {
+    $category = Category::factory()->create();
+    $tagA = Tag::factory()->create();
+    $tagB = Tag::factory()->create();
+    $tagC = Tag::factory()->create();
+
+    $source = Post::factory()->published()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $category->id,
+    ]);
+    $source->tags()->attach([$tagA->id, $tagB->id, $tagC->id]);
+
+    // Two shared tags — strongest match.
+    $twoTags = Post::factory()->published()->create(['user_id' => $this->user->id]);
+    $twoTags->tags()->attach([$tagA->id, $tagB->id]);
+
+    // One shared tag.
+    $oneTag = Post::factory()->published()->create(['user_id' => $this->user->id]);
+    $oneTag->tags()->attach([$tagA->id]);
+
+    // No shared tags but the same category — the fallback rung.
+    $categoryOnly = Post::factory()->published()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $category->id,
+    ]);
+
+    // Neither a shared tag nor the category — must never appear.
+    $unrelated = Post::factory()->published()->create(['user_id' => $this->user->id]);
+
+    $related = $source->related();
+
+    expect($related->pluck('id')->all())->toBe([$twoTags->id, $oneTag->id, $categoryOnly->id])
+        ->and($related->pluck('id')->all())->not->toContain($unrelated->id);
+});
+
+it('falls back to a shared category when no tags overlap', function () {
+    $category = Category::factory()->create();
+    $other = Category::factory()->create();
+
+    $source = Post::factory()->published()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $category->id,
+    ]);
+
+    $sameCategory = Post::factory()->published()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $category->id,
+    ]);
+
+    Post::factory()->published()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $other->id,
+    ]);
+
+    expect($source->related()->pluck('id')->all())->toBe([$sameCategory->id]);
+});
+
+it('excludes the source post and any unpublished posts', function () {
+    $tag = Tag::factory()->create();
+
+    $source = Post::factory()->published()->create(['user_id' => $this->user->id]);
+    $source->tags()->attach($tag->id);
+
+    // Draft, scheduled and future-dated peers share the tag but are not public.
+    $draft = Post::factory()->create(['user_id' => $this->user->id]);
+    $draft->tags()->attach($tag->id);
+
+    $future = Post::factory()->scheduled(now()->addDay())->create(['user_id' => $this->user->id]);
+    $future->tags()->attach($tag->id);
+
+    $peer = Post::factory()->published()->create(['user_id' => $this->user->id]);
+    $peer->tags()->attach($tag->id);
+
+    $ids = $source->related()->pluck('id')->all();
+
+    expect($ids)->toBe([$peer->id])
+        ->and($ids)->not->toContain($source->id);
+});
+
+it('returns an empty collection for a post with no tags or category', function () {
+    $source = Post::factory()->published()->create(['user_id' => $this->user->id]);
+
+    // A published sibling exists but is unrelated; nothing should surface.
+    Post::factory()->published()->create(['user_id' => $this->user->id]);
+
+    expect($source->related())->toBeEmpty();
+});
+
+it('honours the limit argument', function () {
+    $category = Category::factory()->create();
+
+    $source = Post::factory()->published()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $category->id,
+    ]);
+
+    Post::factory()->count(5)->published()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $category->id,
+    ]);
+
+    expect($source->related(2))->toHaveCount(2);
+});

--- a/tests/Feature/Support/FeedBuilderTest.php
+++ b/tests/Feature/Support/FeedBuilderTest.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Models\Category;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Support\FeedBuilder;
+use Kurt\Modules\Blog\Tests\Stubs\StubUser;
+
+beforeEach(function () {
+    $this->user = StubUser::create(['email' => 'author@example.com']);
+});
+
+it('builds a well-formed RSS document with the published posts, newest first', function () {
+    Post::factory()->published()->create([
+        'user_id' => $this->user->id,
+        'published_at' => now()->subDays(3),
+        'title' => ['en' => 'Old Post'],
+    ]);
+    Post::factory()->published()->create([
+        'user_id' => $this->user->id,
+        'published_at' => now()->subDay(),
+        'title' => ['en' => 'New Post'],
+    ]);
+
+    // A draft and a future-scheduled post must not leak into the feed.
+    Post::factory()->create(['user_id' => $this->user->id, 'title' => ['en' => 'Draft Post']]);
+    Post::factory()->scheduled(now()->addDay())->create(['user_id' => $this->user->id]);
+
+    $xml = FeedBuilder::make()->toRss();
+
+    libxml_use_internal_errors(true);
+    $feed = simplexml_load_string($xml);
+
+    expect($feed)->not->toBeFalse();
+
+    $titles = [];
+    foreach ($feed->channel->item as $item) {
+        $titles[] = (string) $item->title;
+    }
+
+    expect($titles)->toBe(['New Post', 'Old Post']);
+});
+
+it('escapes special characters and stays well-formed', function () {
+    Post::factory()->published()->create([
+        'user_id' => $this->user->id,
+        'title' => ['en' => 'Tips & Tricks <alpha>'],
+    ]);
+
+    $xml = FeedBuilder::make()->toRss();
+
+    libxml_use_internal_errors(true);
+    $feed = simplexml_load_string($xml);
+
+    expect($feed)->not->toBeFalse()
+        ->and((string) $feed->channel->item[0]->title)->toBe('Tips & Tricks <alpha>');
+});
+
+it('respects the published scope and the configured limit in the data structure', function () {
+    Post::factory()->count(3)->published()->create(['user_id' => $this->user->id]);
+    Post::factory()->create(['user_id' => $this->user->id]);
+
+    $data = FeedBuilder::make()->limit(2)->toArray();
+
+    expect($data['items'])->toHaveCount(2)
+        ->and($data)->toHaveKeys(['title', 'link', 'description', 'items']);
+});
+
+it('can restrict the feed to a single category', function () {
+    $category = Category::factory()->create();
+
+    Post::factory()->published()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $category->id,
+        'title' => ['en' => 'In Category'],
+    ]);
+    Post::factory()->published()->create([
+        'user_id' => $this->user->id,
+        'title' => ['en' => 'Out of Category'],
+    ]);
+
+    $data = FeedBuilder::make()->forCategory($category)->toArray();
+
+    expect(array_column($data['items'], 'title'))->toBe(['In Category']);
+});

--- a/tests/Feature/Support/SitemapBuilderTest.php
+++ b/tests/Feature/Support/SitemapBuilderTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Models\Category;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Models\Tag;
+use Kurt\Modules\Blog\Support\SitemapBuilder;
+use Kurt\Modules\Blog\Tests\Stubs\StubUser;
+
+beforeEach(function () {
+    $this->user = StubUser::create(['email' => 'author@example.com']);
+});
+
+it('emits entries only for published posts and categories that hold public content', function () {
+    $category = Category::factory()->create();
+    $post = Post::factory()->published()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $category->id,
+    ]);
+
+    // A category whose only post is a draft is not public content.
+    $draftCategory = Category::factory()->create();
+    Post::factory()->create([
+        'user_id' => $this->user->id,
+        'category_id' => $draftCategory->id,
+    ]);
+
+    // A category with no posts at all.
+    $emptyCategory = Category::factory()->create();
+
+    // A draft post with no category — excluded entirely.
+    Post::factory()->create(['user_id' => $this->user->id]);
+
+    $entries = SitemapBuilder::make()->entries();
+    $locs = $entries->pluck('loc')->all();
+
+    expect($locs)->toContain(url('blog/'.$post->slug))
+        ->and($locs)->toContain(url('blog/category/'.$category->slug))
+        ->and($locs)->not->toContain(url('blog/category/'.$draftCategory->slug))
+        ->and($locs)->not->toContain(url('blog/category/'.$emptyCategory->slug))
+        ->and($entries)->toHaveCount(2);
+});
+
+it('includes tags only when opted in, and only tags with published posts', function () {
+    $usedTag = Tag::factory()->create();
+    $unusedTag = Tag::factory()->create();
+    $draftTag = Tag::factory()->create();
+
+    $post = Post::factory()->published()->create(['user_id' => $this->user->id]);
+    $post->tags()->attach($usedTag->id);
+
+    $draft = Post::factory()->create(['user_id' => $this->user->id]);
+    $draft->tags()->attach($draftTag->id);
+
+    $without = SitemapBuilder::make()->entries()->pluck('loc')->all();
+    expect($without)->not->toContain(url('blog/tag/'.$usedTag->slug));
+
+    $with = SitemapBuilder::make()->includeTags()->entries()->pluck('loc')->all();
+
+    expect($with)->toContain(url('blog/tag/'.$usedTag->slug))
+        ->and($with)->not->toContain(url('blog/tag/'.$unusedTag->slug))
+        ->and($with)->not->toContain(url('blog/tag/'.$draftTag->slug));
+});
+
+it('exposes loc, lastmod and changefreq for each entry', function () {
+    Post::factory()->published()->create(['user_id' => $this->user->id]);
+
+    $array = SitemapBuilder::make()->toArray();
+
+    expect($array[0])->toHaveKeys(['loc', 'lastmod', 'changefreq'])
+        ->and($array[0]['changefreq'])->toBe('weekly');
+});


### PR DESCRIPTION
Adds three roadmap features to the headless blog module. All are read-only query/data helpers the consuming app renders or wires to routes — no new routes, views, or schema.

## Features

### 1. Related posts
`Post::related(int $limit = 5)` (backed by a `scopeRelatedTo`) returns published, non-self posts ranked by shared-tag overlap first, then a shared category as a fallback. Runs as a single query (no N+1): only the source post's tag ids are loaded up front, and the overlap count is a correlated subquery over the pivot. A post with neither tags nor a category yields an empty collection.

### 2. RSS / feed data — `Support\FeedBuilder`
Produces a valid RSS 2.0 XML string (`toRss()`) or a plain data structure (`toArray()`) for the latest published posts. Configurable count, optional per-category scope, overridable channel metadata and per-post URL resolver. All dynamic text is XML-escaped, so the output is always well-formed. Documented with a route example (headless).

### 3. Sitemap hooks — `Support\SitemapBuilder` + `SitemapEntry`
Returns `loc`/`lastmod`/`changefreq`/`priority` entries for public content only: published posts, categories holding at least one published post, and (opt-in) tags that do. The category/tag membership is derived from the Post `published` scope so the definition of "public" stays in one place.

Adds `feed` and `sitemap` default blocks to `config/blog.php`; updates README + CHANGELOG.

## Tests
New: `RelatedPostsTest` (tag-overlap ranking, category fallback, excludes self/unpublished, empty case, limit), `FeedBuilderTest` (well-formed XML, escaping, published scope + limit, per-category), `SitemapBuilderTest` (public-content-only entries, opt-in tags, entry shape).

## Gates
- pest: 74 passed, 34 skipped (Filament matrix)
- phpstan level 8: clean
- pint: clean on changed files