### PR TITLE
feat(blog): out-of-the-box REST API on the Core API kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,19 @@ All notable changes follow [Keep a Changelog](https://keepachangelog.com/en/1.1.
   categories with published posts, and (opt-in) tags, for the app to feed into
   its own sitemap.
 - `feed` and `sitemap` default blocks in `config/blog.php`.
+- **REST API** — an opt-in JSON API built on the Core API kit
+  (`ozankurt/laravel-modules-core` ^2.2). Full REST for posts, categories, tags
+  and comments plus `publish`/`unpublish`/`related` post actions. Reads are
+  public and respect the published scope; writes require auth and are guarded by
+  the module Policies. Safe by default: nothing registers unless
+  `BLOG_HTTP_MODE=api`. Adds the `http` block to `config/blog.php`, a
+  `routes/api.php` file, Resources, FormRequests and controllers under
+  `src/Http`.
+
+### Fixed
+- Policies now resolve the access gate via the `Gate` contract instead of the
+  unbound `app('gate')` container alias, so the `canManageBlog` staff check works
+  when a Policy is invoked (previously unreachable in the headless module).
 
 ## [2.2.1] - 2026-05-31
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Headless blog module for Laravel: posts, categories, tags, comments, scheduled p
 
 - PHP 8.4+
 - Laravel 12.x or 13.x
-- `ozankurt/laravel-modules-core` v2.x
+- `ozankurt/laravel-modules-core` v2.2+ (ships the API kit)
 
 ## Installation
 
@@ -30,6 +30,7 @@ php artisan migrate
 - `Kurt\Modules\Blog\Support\VideoUrl::parse()` for YouTube / Vimeo / DailyMotion URL parsing.
 - `Kurt\Modules\Blog\Support\SeoMetadata::forPost()` for SEO meta resolution.
 - `Kurt\Modules\Blog\Support\FeedBuilder` for RSS 2.0 / feed data, and `SitemapBuilder` for sitemap entries — see [Headless helpers](#headless-helpers).
+- An opt-in JSON REST API (posts, categories, tags, comments + `publish`/`unpublish`/`related` actions) — see [API](#api).
 - Console commands: `blog:publish-due`, `blog:upgrade-translations`, `blog:demo`.
 - Domain events: `PostCreated`, `PostUpdated`, `PostPublished`, `PostArchived`, `CommentCreated`, `CommentApproved`, `CommentRejected`, ...
 
@@ -111,6 +112,84 @@ $rows = SitemapBuilder::make()->toArray();            // array of loc/lastmod/..
 Feed the entries into whichever sitemap package or response your app already
 uses. Per-type change frequencies live under the `sitemap` key in
 `config/blog.php`.
+
+## API
+
+The module ships an out-of-the-box JSON REST API built on the Core API kit
+(`ozankurt/laravel-modules-core` v2.2+). It is **safe by default**: nothing is
+registered until you opt in.
+
+### Enabling
+
+Set the mode to `api` (or `ui`) — headless registers no routes:
+
+```dotenv
+BLOG_HTTP_MODE=api
+```
+
+Everything is driven by the `http` block published to `config/blog.php`:
+
+```php
+'http' => [
+    'mode' => env('BLOG_HTTP_MODE', 'headless'), // headless | api | ui
+    'prefix' => 'api/blog',                       // URL prefix for every route
+    'middleware' => ['api'],                      // base middleware (all routes)
+    'auth_middleware' => ['auth'],                // added to write routes; e.g. ['auth:sanctum']
+    'rate_limit' => '60,1',                        // maxAttempts,decayMinutes for throttle:blog-api
+],
+```
+
+Every route is throttled by the named `blog-api` limiter (keyed by user id, or
+client IP for guests).
+
+### Endpoints
+
+All paths are relative to the configured prefix (default `/api/blog`). Responses
+use the Core `{ "data": ..., "meta": ... }` envelope; index endpoints add
+`meta.pagination`.
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| GET | `/posts` | public | List posts. `?sort=created_at,-published_at,title`, `?filter[category]=`, `?filter[status]=`, `?filter[author]=`, `?per_page=`. |
+| GET | `/posts/{id\|slug}` | public | Show a post by id or slug. |
+| POST | `/posts` | auth | Create a post (authored by the current user). |
+| PATCH/PUT | `/posts/{id\|slug}` | auth | Update a post. |
+| DELETE | `/posts/{id\|slug}` | auth | Soft-delete a post (204). |
+| POST | `/posts/{id\|slug}/publish` | auth | Publish now (backfills `published_at`). |
+| POST | `/posts/{id\|slug}/unpublish` | auth | Revert to draft. |
+| GET | `/posts/{id\|slug}/related` | public | Related posts (shared tags, then category). `?limit=`. |
+| GET | `/posts/{id\|slug}/comments` | public | Approved comments for a post (staff see all). |
+| POST | `/posts/{id\|slug}/comments` | auth | Add a comment to a post (201). |
+| PATCH/PUT | `/comments/{id}` | auth | Edit a comment. |
+| DELETE | `/comments/{id}` | auth | Soft-delete a comment (204). |
+| GET | `/categories` | public | List categories. |
+| GET | `/categories/{id}` | public | Show a category. |
+| POST | `/categories` | auth | Create a category. |
+| PATCH/PUT | `/categories/{id}` | auth | Update a category. |
+| DELETE | `/categories/{id}` | auth | Soft-delete a category (204). |
+| GET | `/tags` | public | List tags. |
+| GET | `/tags/{id}` | public | Show a tag. |
+| POST | `/tags` | auth | Create a tag. |
+| DELETE | `/tags/{id}` | auth | Soft-delete a tag (204). |
+
+### Auth & policies
+
+- **Reads are public** and respect the published scope: guests and non-staff
+  readers only see published posts (an authenticated reader also sees their own
+  drafts; staff see everything). Requesting a draft you may not view returns 403.
+- **Writes require authentication** (the `auth_middleware`) and are additionally
+  guarded by the module's Policies (`PostPolicy`, `CommentPolicy`,
+  `CategoryPolicy`, `TagPolicy`) via `$this->authorize()` in every write action.
+  Post/comment writes allow the owner or staff; category/tag writes are
+  staff-only. "Staff" is whatever your app grants through the `canManageBlog`
+  gate — define it in your `AuthServiceProvider`:
+
+  ```php
+  Gate::define('canManageBlog', fn ($user) => $user->is_admin);
+  ```
+
+Requests are validated with FormRequests, so invalid payloads return the
+standard `422` `{ "message": ..., "errors": ... }` envelope.
 
 ## Filament admin
 

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     "illuminate/contracts": "^12.0 || ^13.0",
     "illuminate/database": "^12.0 || ^13.0",
     "illuminate/support": "^12.0 || ^13.0",
-    "ozankurt/laravel-modules-core": "^2.0",
+    "ozankurt/laravel-modules-core": "^2.2",
     "ozankurt/laravel-modules-interactions": "^1.3",
     "spatie/laravel-medialibrary": "^11.0",
     "spatie/laravel-package-tools": "^1.92",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "443863f6974c8af598b91f785fd07cb5",
+    "content-hash": "6794114d6df2615f8fd9fa2b534e071d",
     "packages": [
         {
             "name": "brick/math",
@@ -2716,22 +2716,22 @@
         },
         {
             "name": "ozankurt/laravel-modules-core",
-            "version": "v2.0.1",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/OzanKurt/KurtModules-Core.git",
-                "reference": "6d020b89d0998e959f376506462d60f392799dbb"
+                "reference": "f8494de8a22dbd971e1b34d609e6449ea860727d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/OzanKurt/KurtModules-Core/zipball/6d020b89d0998e959f376506462d60f392799dbb",
-                "reference": "6d020b89d0998e959f376506462d60f392799dbb",
+                "url": "https://api.github.com/repos/OzanKurt/KurtModules-Core/zipball/f8494de8a22dbd971e1b34d609e6449ea860727d",
+                "reference": "f8494de8a22dbd971e1b34d609e6449ea860727d",
                 "shasum": ""
             },
             "require": {
-                "illuminate/contracts": "^12.0 || ^13.0",
-                "illuminate/database": "^12.0 || ^13.0",
-                "illuminate/support": "^12.0 || ^13.0",
+                "illuminate/contracts": "^12.0",
+                "illuminate/database": "^12.0",
+                "illuminate/support": "^12.0",
                 "php": "^8.3",
                 "spatie/laravel-package-tools": "^1.92"
             },
@@ -2796,10 +2796,10 @@
                 "laravel"
             ],
             "support": {
-                "source": "https://github.com/OzanKurt/KurtModules-Core/tree/v2.0.1",
+                "source": "https://github.com/OzanKurt/KurtModules-Core/tree/v2.2.0",
                 "issues": "https://github.com/OzanKurt/KurtModules-Core/issues"
             },
-            "time": "2026-06-28T22:57:52+00:00"
+            "time": "2026-07-20T20:48:49+00:00"
         },
         {
             "name": "ozankurt/laravel-modules-interactions",

--- a/config/blog.php
+++ b/config/blog.php
@@ -42,6 +42,19 @@ return [
 
     'route_prefix' => 'blog',
 
+    // REST API surface (Core API kit). Safe-by-default: `mode` stays `headless`
+    // so no routes are registered until a consumer opts in with
+    // BLOG_HTTP_MODE=api (or `ui`). Read routes (index/show) are public and
+    // respect the published scope; write routes additionally require the
+    // `auth_middleware`. Every route is throttled by the `blog-api` limiter.
+    'http' => [
+        'mode' => env('BLOG_HTTP_MODE', 'headless'),
+        'prefix' => 'api/blog',
+        'middleware' => ['api'],
+        'auth_middleware' => ['auth'],
+        'rate_limit' => '60,1',
+    ],
+
     // FeedBuilder defaults. `title`/`description` fall back to the app name and
     // a generic label when null; `limit` caps how many latest posts a feed
     // carries. All are overridable per feed via the builder's fluent setters.

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -16,6 +16,9 @@
         <testsuite name="Feature">
             <directory>tests/Feature</directory>
         </testsuite>
+        <testsuite name="Api">
+            <directory>tests/Api</directory>
+        </testsuite>
     </testsuites>
     <source>
         <include>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Route;
+use Kurt\Modules\Blog\Http\Controllers\Api\CategoryController;
+use Kurt\Modules\Blog\Http\Controllers\Api\CommentController;
+use Kurt\Modules\Blog\Http\Controllers\Api\PostController;
+use Kurt\Modules\Blog\Http\Controllers\Api\TagController;
+
+/*
+|--------------------------------------------------------------------------
+| Blog REST API routes
+|--------------------------------------------------------------------------
+|
+| This file is loaded by PackageServiceProvider::registerModuleApi() inside a
+| Route::group() built from config/blog.php's `http` block (prefix `api/blog`,
+| the `api` middleware, and the `throttle:blog-api` limiter). Read routes are
+| declared plainly; write routes append the module's auth middleware per route
+| (never nest another ApiRouteGroup, which would double the prefix/throttle).
+|
+*/
+
+/** @var array<int, string> $auth */
+$auth = config('blog.http.auth_middleware', ['auth']);
+
+// Posts — reads (public, published scope respected).
+Route::get('posts', [PostController::class, 'index'])->name('posts.index');
+Route::get('posts/{post}/related', [PostController::class, 'related'])->name('posts.related');
+Route::get('posts/{post}/comments', [CommentController::class, 'index'])->name('comments.index');
+Route::get('posts/{post}', [PostController::class, 'show'])->name('posts.show');
+
+// Posts — writes (auth + Policy).
+Route::post('posts', [PostController::class, 'store'])->middleware($auth)->name('posts.store');
+Route::patch('posts/{post}', [PostController::class, 'update'])->middleware($auth)->name('posts.update');
+Route::put('posts/{post}', [PostController::class, 'update'])->middleware($auth);
+Route::delete('posts/{post}', [PostController::class, 'destroy'])->middleware($auth)->name('posts.destroy');
+Route::post('posts/{post}/publish', [PostController::class, 'publish'])->middleware($auth)->name('posts.publish');
+Route::post('posts/{post}/unpublish', [PostController::class, 'unpublish'])->middleware($auth)->name('posts.unpublish');
+
+// Comments — store on a post, update/destroy by id (auth + Policy).
+Route::post('posts/{post}/comments', [CommentController::class, 'store'])->middleware($auth)->name('comments.store');
+Route::patch('comments/{comment}', [CommentController::class, 'update'])->middleware($auth)->name('comments.update');
+Route::put('comments/{comment}', [CommentController::class, 'update'])->middleware($auth);
+Route::delete('comments/{comment}', [CommentController::class, 'destroy'])->middleware($auth)->name('comments.destroy');
+
+// Categories — full REST.
+Route::get('categories', [CategoryController::class, 'index'])->name('categories.index');
+Route::get('categories/{category}', [CategoryController::class, 'show'])->name('categories.show');
+Route::post('categories', [CategoryController::class, 'store'])->middleware($auth)->name('categories.store');
+Route::patch('categories/{category}', [CategoryController::class, 'update'])->middleware($auth)->name('categories.update');
+Route::put('categories/{category}', [CategoryController::class, 'update'])->middleware($auth);
+Route::delete('categories/{category}', [CategoryController::class, 'destroy'])->middleware($auth)->name('categories.destroy');
+
+// Tags — index/show public; store/destroy for staff.
+Route::get('tags', [TagController::class, 'index'])->name('tags.index');
+Route::get('tags/{tag}', [TagController::class, 'show'])->name('tags.show');
+Route::post('tags', [TagController::class, 'store'])->middleware($auth)->name('tags.store');
+Route::delete('tags/{tag}', [TagController::class, 'destroy'])->middleware($auth)->name('tags.destroy');

--- a/src/Http/Controllers/Api/CategoryController.php
+++ b/src/Http/Controllers/Api/CategoryController.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Kurt\Modules\Blog\Http\Requests\StoreCategoryRequest;
+use Kurt\Modules\Blog\Http\Requests\UpdateCategoryRequest;
+use Kurt\Modules\Blog\Http\Resources\CategoryResource;
+use Kurt\Modules\Blog\Models\Category;
+use Kurt\Modules\Core\Http\Concerns\HandlesApiQuery;
+use Kurt\Modules\Core\Http\Controllers\ApiController;
+
+final class CategoryController extends ApiController
+{
+    use HandlesApiQuery;
+
+    public function index(Request $request): JsonResponse
+    {
+        $query = Category::query();
+
+        $query = $this->applyApiFilters($query, $request, ['parent_id' => 'exact', 'name' => 'like']);
+
+        $sort = $request->query('sort');
+        $query = $this->applyApiSorts($query, $request, ['position', 'name', 'created_at']);
+
+        if (! is_string($sort) || $sort === '') {
+            $query->orderBy('position')->orderBy('id');
+        }
+
+        return $this->respondPaginated($this->apiPaginate($query, $request), CategoryResource::class);
+    }
+
+    public function show(Category $category): JsonResponse
+    {
+        $this->authorize('view', $category);
+
+        return $this->respond(CategoryResource::make($category));
+    }
+
+    public function store(StoreCategoryRequest $request): JsonResponse
+    {
+        $this->authorize('create', Category::class);
+
+        $category = Category::create($request->validated());
+
+        return $this->respondCreated(CategoryResource::make($category));
+    }
+
+    public function update(UpdateCategoryRequest $request, Category $category): JsonResponse
+    {
+        $this->authorize('update', $category);
+
+        $category->update($request->validated());
+
+        return $this->respond(CategoryResource::make($category));
+    }
+
+    public function destroy(Category $category): JsonResponse
+    {
+        $this->authorize('delete', $category);
+
+        $category->delete();
+
+        return $this->respondNoContent();
+    }
+}

--- a/src/Http/Controllers/Api/CommentController.php
+++ b/src/Http/Controllers/Api/CommentController.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Controllers\Api;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Kurt\Modules\Blog\Http\Requests\StoreCommentRequest;
+use Kurt\Modules\Blog\Http\Requests\UpdateCommentRequest;
+use Kurt\Modules\Blog\Http\Resources\CommentResource;
+use Kurt\Modules\Blog\Models\Comment;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Core\Http\Concerns\HandlesApiQuery;
+use Kurt\Modules\Core\Http\Controllers\ApiController;
+use Kurt\Modules\Interactions\Comments\Enums\CommentStatus;
+
+final class CommentController extends ApiController
+{
+    use HandlesApiQuery;
+
+    /**
+     * Approved comments for a post. Staff additionally see pending/rejected
+     * comments so they can moderate through the API.
+     */
+    public function index(Request $request, string $post): JsonResponse
+    {
+        $model = $this->resolvePost($post);
+
+        $this->authorize('view', $model);
+
+        $query = $model->comments()->getQuery();
+
+        $user = $request->user();
+
+        if (! ($user !== null && Gate::allows('canManageBlog', $user))) {
+            $query->where('status', CommentStatus::Published->value);
+        }
+
+        $query->orderByDesc('id');
+
+        return $this->respondPaginated($this->apiPaginate($query, $request), CommentResource::class);
+    }
+
+    public function store(StoreCommentRequest $request, string $post): JsonResponse
+    {
+        $model = $this->resolvePost($post);
+
+        $this->authorize('create', Comment::class);
+
+        /** @var Authenticatable $user */
+        $user = $request->user();
+
+        $comment = Comment::create([
+            'post_id' => $model->getKey(),
+            'user_id' => $user->getAuthIdentifier(),
+            'parent_id' => $request->validated('parent_id'),
+            'body' => $request->validated('body'),
+        ]);
+
+        return $this->respondCreated(CommentResource::make($comment));
+    }
+
+    public function update(UpdateCommentRequest $request, Comment $comment): JsonResponse
+    {
+        $this->authorize('update', $comment);
+
+        $comment->update(['body' => $request->validated('body')]);
+
+        return $this->respond(CommentResource::make($comment));
+    }
+
+    public function destroy(Comment $comment): JsonResponse
+    {
+        $this->authorize('delete', $comment);
+
+        $comment->delete();
+
+        return $this->respondNoContent();
+    }
+
+    private function resolvePost(string $key): Post
+    {
+        return Post::query()
+            ->where(fn (Builder $q) => $q->where('id', $key)->orWhere('slug', $key))
+            ->firstOrFail();
+    }
+}

--- a/src/Http/Controllers/Api/PostController.php
+++ b/src/Http/Controllers/Api/PostController.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Controllers\Api;
+
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Gate;
+use Kurt\Modules\Blog\Enums\PostStatus;
+use Kurt\Modules\Blog\Http\Requests\StorePostRequest;
+use Kurt\Modules\Blog\Http\Requests\UpdatePostRequest;
+use Kurt\Modules\Blog\Http\Resources\PostResource;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Core\Http\Concerns\HandlesApiQuery;
+use Kurt\Modules\Core\Http\Controllers\ApiController;
+
+final class PostController extends ApiController
+{
+    use HandlesApiQuery;
+
+    /**
+     * Paginated list of posts. Guests and non-staff readers only see published
+     * posts (authenticated readers additionally see their own drafts; staff see
+     * everything). Supports `?sort=`, `?filter[...]=` and `?per_page=`.
+     */
+    public function index(Request $request): JsonResponse
+    {
+        $query = $this->applyVisibility(
+            Post::query()->with(['category', 'tags']),
+            $request->user(),
+        );
+
+        $this->normaliseFilters($request);
+
+        $query = $this->applyApiFilters($query, $request, [
+            'category_id' => 'exact',
+            'status' => 'exact',
+            'user_id' => 'exact',
+        ]);
+
+        $sort = $request->query('sort');
+        $query = $this->applyApiSorts($query, $request, ['created_at', 'published_at', 'title']);
+
+        if (! is_string($sort) || $sort === '') {
+            $query->orderByDesc('published_at')->orderByDesc('id');
+        }
+
+        return $this->respondPaginated($this->apiPaginate($query, $request), PostResource::class);
+    }
+
+    /**
+     * Show a single post resolved by id or slug.
+     */
+    public function show(Request $request, string $post): JsonResponse
+    {
+        $model = $this->resolvePost($post);
+
+        $this->authorize('view', $model);
+
+        return $this->respond(PostResource::make($model->load(['category', 'tags'])));
+    }
+
+    public function store(StorePostRequest $request): JsonResponse
+    {
+        $this->authorize('create', Post::class);
+
+        $data = $request->validated();
+        $tags = $data['tags'] ?? null;
+        unset($data['tags']);
+
+        /** @var Authenticatable $user */
+        $user = $request->user();
+        $data['user_id'] = $user->getAuthIdentifier();
+
+        $post = Post::create($data);
+
+        if (is_array($tags)) {
+            $post->tags()->sync($tags);
+        }
+
+        // Reload so DB-side defaults (status, type, view_count) are hydrated on
+        // the instance before it is serialised.
+        $post->refresh();
+
+        return $this->respondCreated(PostResource::make($post->load(['category', 'tags'])));
+    }
+
+    public function update(UpdatePostRequest $request, string $post): JsonResponse
+    {
+        $model = $this->resolvePost($post);
+
+        $this->authorize('update', $model);
+
+        $data = $request->validated();
+        $hasTags = array_key_exists('tags', $data);
+        $tags = $data['tags'] ?? null;
+        unset($data['tags']);
+
+        $model->update($data);
+
+        if ($hasTags) {
+            $model->tags()->sync(is_array($tags) ? $tags : []);
+        }
+
+        return $this->respond(PostResource::make($model->load(['category', 'tags'])));
+    }
+
+    public function destroy(string $post): JsonResponse
+    {
+        $model = $this->resolvePost($post);
+
+        $this->authorize('delete', $model);
+
+        $model->delete();
+
+        return $this->respondNoContent();
+    }
+
+    /**
+     * Publish a post now. Backfills `published_at` when unset so the post is
+     * immediately live. The PostObserver fires PostPublished on the transition.
+     */
+    public function publish(string $post): JsonResponse
+    {
+        $model = $this->resolvePost($post);
+
+        $this->authorize('update', $model);
+
+        $model->status = PostStatus::Published;
+
+        if ($model->published_at === null) {
+            $model->published_at = now();
+        }
+
+        $model->save();
+
+        return $this->respond(PostResource::make($model->load(['category', 'tags'])));
+    }
+
+    /**
+     * Revert a post to draft so it no longer appears in published listings.
+     */
+    public function unpublish(string $post): JsonResponse
+    {
+        $model = $this->resolvePost($post);
+
+        $this->authorize('update', $model);
+
+        $model->status = PostStatus::Draft;
+        $model->save();
+
+        return $this->respond(PostResource::make($model->load(['category', 'tags'])));
+    }
+
+    /**
+     * Posts most related to the given one (shared tags, then shared category).
+     */
+    public function related(Request $request, string $post): JsonResponse
+    {
+        $model = $this->resolvePost($post);
+
+        $this->authorize('view', $model);
+
+        $limit = min(50, max(1, $request->integer('limit', 5)));
+
+        $related = $model->related($limit)->load(['category', 'tags']);
+
+        return $this->respond(PostResource::collection($related));
+    }
+
+    private function resolvePost(string $key): Post
+    {
+        return Post::query()
+            ->where(fn (Builder $q) => $q->where('id', $key)->orWhere('slug', $key))
+            ->firstOrFail();
+    }
+
+    /**
+     * Constrain a post query to what the given user may see.
+     *
+     * @param  Builder<Post>  $query
+     * @return Builder<Post>
+     */
+    private function applyVisibility(Builder $query, ?Authenticatable $user): Builder
+    {
+        if ($user !== null && Gate::allows('canManageBlog', $user)) {
+            return $query;
+        }
+
+        if ($user === null) {
+            return $query->published();
+        }
+
+        return $query->where(function (Builder $inner) use ($user): void {
+            $inner->where('status', PostStatus::Published->value)
+                ->where('published_at', '<=', now())
+                ->orWhere('user_id', $user->getAuthIdentifier());
+        });
+    }
+
+    /**
+     * Rewrite the friendly `filter[category]` / `filter[author]` params onto the
+     * underlying `category_id` / `user_id` columns the allow-list expects.
+     */
+    private function normaliseFilters(Request $request): void
+    {
+        $filters = $request->query('filter');
+
+        if (! is_array($filters)) {
+            return;
+        }
+
+        $map = ['category' => 'category_id', 'author' => 'user_id'];
+        $normalised = [];
+
+        foreach ($filters as $key => $value) {
+            $column = is_string($key) && array_key_exists($key, $map) ? $map[$key] : $key;
+            $normalised[$column] = $value;
+        }
+
+        $request->query->set('filter', $normalised);
+    }
+}

--- a/src/Http/Controllers/Api/TagController.php
+++ b/src/Http/Controllers/Api/TagController.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Controllers\Api;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Kurt\Modules\Blog\Http\Requests\StoreTagRequest;
+use Kurt\Modules\Blog\Http\Resources\TagResource;
+use Kurt\Modules\Blog\Models\Tag;
+use Kurt\Modules\Core\Http\Concerns\HandlesApiQuery;
+use Kurt\Modules\Core\Http\Controllers\ApiController;
+
+final class TagController extends ApiController
+{
+    use HandlesApiQuery;
+
+    public function index(Request $request): JsonResponse
+    {
+        $query = Tag::query();
+
+        $query = $this->applyApiFilters($query, $request, ['name' => 'like']);
+
+        $sort = $request->query('sort');
+        $query = $this->applyApiSorts($query, $request, ['name', 'created_at']);
+
+        if (! is_string($sort) || $sort === '') {
+            $query->orderBy('name')->orderBy('id');
+        }
+
+        return $this->respondPaginated($this->apiPaginate($query, $request), TagResource::class);
+    }
+
+    public function show(Tag $tag): JsonResponse
+    {
+        $this->authorize('view', $tag);
+
+        return $this->respond(TagResource::make($tag));
+    }
+
+    public function store(StoreTagRequest $request): JsonResponse
+    {
+        $this->authorize('create', Tag::class);
+
+        $tag = Tag::create($request->validated());
+
+        return $this->respondCreated(TagResource::make($tag));
+    }
+
+    public function destroy(Tag $tag): JsonResponse
+    {
+        $this->authorize('delete', $tag);
+
+        $tag->delete();
+
+        return $this->respondNoContent();
+    }
+}

--- a/src/Http/Requests/StoreCategoryRequest.php
+++ b/src/Http/Requests/StoreCategoryRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'parent_id' => ['nullable', 'integer', 'exists:blog_categories,id'],
+            'position' => ['nullable', 'integer'],
+        ];
+    }
+}

--- a/src/Http/Requests/StoreCommentRequest.php
+++ b/src/Http/Requests/StoreCommentRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreCommentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string'],
+            'parent_id' => ['nullable', 'integer', 'exists:interactions_comments,id'],
+        ];
+    }
+}

--- a/src/Http/Requests/StorePostRequest.php
+++ b/src/Http/Requests/StorePostRequest.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Kurt\Modules\Blog\Enums\PostStatus;
+use Kurt\Modules\Blog\Enums\PostType;
+
+class StorePostRequest extends FormRequest
+{
+    /**
+     * Authorization is enforced in the controller via the Post policy so the
+     * bound model (and its ownership) is available.
+     */
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255'],
+            'excerpt' => ['nullable', 'string'],
+            'body' => ['nullable', 'string'],
+            'status' => ['nullable', Rule::enum(PostStatus::class)],
+            'type' => ['nullable', Rule::enum(PostType::class)],
+            'video_url' => ['nullable', 'string', 'url'],
+            'category_id' => ['nullable', 'integer', 'exists:blog_categories,id'],
+            'published_at' => ['nullable', 'date'],
+            'scheduled_for' => ['nullable', 'date'],
+            'meta_title' => ['nullable', 'string', 'max:255'],
+            'meta_description' => ['nullable', 'string'],
+            'meta_og_image' => ['nullable', 'string'],
+            'tags' => ['nullable', 'array'],
+            'tags.*' => ['integer', 'exists:blog_tags,id'],
+        ];
+    }
+}

--- a/src/Http/Requests/StoreTagRequest.php
+++ b/src/Http/Requests/StoreTagRequest.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreTagRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['required', 'string', 'max:255'],
+            'slug' => ['nullable', 'string', 'max:255'],
+            'description' => ['nullable', 'string'],
+            'color' => ['nullable', 'string', 'max:32'],
+        ];
+    }
+}

--- a/src/Http/Requests/UpdateCategoryRequest.php
+++ b/src/Http/Requests/UpdateCategoryRequest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCategoryRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'name' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'description' => ['sometimes', 'nullable', 'string'],
+            'parent_id' => ['sometimes', 'nullable', 'integer', 'exists:blog_categories,id'],
+            'position' => ['sometimes', 'nullable', 'integer'],
+        ];
+    }
+}

--- a/src/Http/Requests/UpdateCommentRequest.php
+++ b/src/Http/Requests/UpdateCommentRequest.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class UpdateCommentRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'body' => ['required', 'string'],
+        ];
+    }
+}

--- a/src/Http/Requests/UpdatePostRequest.php
+++ b/src/Http/Requests/UpdatePostRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+use Kurt\Modules\Blog\Enums\PostStatus;
+use Kurt\Modules\Blog\Enums\PostType;
+
+class UpdatePostRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['sometimes', 'required', 'string', 'max:255'],
+            'slug' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'excerpt' => ['sometimes', 'nullable', 'string'],
+            'body' => ['sometimes', 'nullable', 'string'],
+            'status' => ['sometimes', Rule::enum(PostStatus::class)],
+            'type' => ['sometimes', Rule::enum(PostType::class)],
+            'video_url' => ['sometimes', 'nullable', 'string', 'url'],
+            'category_id' => ['sometimes', 'nullable', 'integer', 'exists:blog_categories,id'],
+            'published_at' => ['sometimes', 'nullable', 'date'],
+            'scheduled_for' => ['sometimes', 'nullable', 'date'],
+            'meta_title' => ['sometimes', 'nullable', 'string', 'max:255'],
+            'meta_description' => ['sometimes', 'nullable', 'string'],
+            'meta_og_image' => ['sometimes', 'nullable', 'string'],
+            'tags' => ['sometimes', 'nullable', 'array'],
+            'tags.*' => ['integer', 'exists:blog_tags,id'],
+        ];
+    }
+}

--- a/src/Http/Resources/CategoryResource.php
+++ b/src/Http/Resources/CategoryResource.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Kurt\Modules\Blog\Models\Category;
+
+/**
+ * @mixin Category
+ */
+final class CategoryResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'slug' => $this->slug,
+            'name' => $this->name,
+            'description' => $this->description,
+            'parent_id' => $this->parent_id,
+            'position' => $this->position,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/src/Http/Resources/CommentResource.php
+++ b/src/Http/Resources/CommentResource.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Kurt\Modules\Blog\Models\Comment;
+
+/**
+ * @mixin Comment
+ */
+final class CommentResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'post_id' => $this->post_id,
+            'user_id' => $this->user_id,
+            'parent_id' => $this->parent_id,
+            'body' => $this->body,
+            'approval' => $this->approval->value,
+            'status' => $this->status->value,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/src/Http/Resources/PostResource.php
+++ b/src/Http/Resources/PostResource.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Kurt\Modules\Blog\Models\Post;
+
+/**
+ * @mixin Post
+ */
+final class PostResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'slug' => $this->slug,
+            'title' => $this->title,
+            'excerpt' => $this->excerpt,
+            'body' => $this->body,
+            'status' => $this->status->value,
+            'type' => $this->type->value,
+            'video_url' => $this->video_url,
+            'view_count' => $this->view_count,
+            'author_id' => $this->user_id,
+            'category_id' => $this->category_id,
+            'published_at' => $this->published_at?->toISOString(),
+            'scheduled_for' => $this->scheduled_for?->toISOString(),
+            'meta_title' => $this->meta_title,
+            'meta_description' => $this->meta_description,
+            'meta_og_image' => $this->meta_og_image,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+            'category' => CategoryResource::make($this->whenLoaded('category')),
+            'tags' => TagResource::collection($this->whenLoaded('tags')),
+        ];
+    }
+}

--- a/src/Http/Resources/TagResource.php
+++ b/src/Http/Resources/TagResource.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Http\Resources;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Kurt\Modules\Blog\Models\Tag;
+
+/**
+ * @mixin Tag
+ */
+final class TagResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'slug' => $this->slug,
+            'name' => $this->name,
+            'description' => $this->description,
+            'color' => $this->color,
+            'created_at' => $this->created_at?->toISOString(),
+            'updated_at' => $this->updated_at?->toISOString(),
+        ];
+    }
+}

--- a/src/Policies/CategoryPolicy.php
+++ b/src/Policies/CategoryPolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kurt\Modules\Blog\Policies;
 
+use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Kurt\Modules\Blog\Models\Category;
 
@@ -31,6 +32,6 @@ final class CategoryPolicy
 
     private function isStaff(Authenticatable $user): bool
     {
-        return app('gate')->allows('canManageBlog', $user);
+        return app(Gate::class)->allows('canManageBlog', $user);
     }
 }

--- a/src/Policies/CommentPolicy.php
+++ b/src/Policies/CommentPolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kurt\Modules\Blog\Policies;
 
+use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Kurt\Modules\Blog\Models\Comment;
 
@@ -41,6 +42,6 @@ final class CommentPolicy
 
     private function isStaff(Authenticatable $user): bool
     {
-        return app('gate')->allows('canManageBlog', $user);
+        return app(Gate::class)->allows('canManageBlog', $user);
     }
 }

--- a/src/Policies/PostPolicy.php
+++ b/src/Policies/PostPolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kurt\Modules\Blog\Policies;
 
+use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Kurt\Modules\Blog\Enums\PostStatus;
 use Kurt\Modules\Blog\Models\Post;
@@ -36,6 +37,6 @@ final class PostPolicy
 
     private function isStaff(Authenticatable $user): bool
     {
-        return app('gate')->allows('canManageBlog', $user);
+        return app(Gate::class)->allows('canManageBlog', $user);
     }
 }

--- a/src/Policies/TagPolicy.php
+++ b/src/Policies/TagPolicy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Kurt\Modules\Blog\Policies;
 
+use Illuminate\Contracts\Auth\Access\Gate;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Kurt\Modules\Blog\Models\Tag;
 
@@ -31,6 +32,6 @@ final class TagPolicy
 
     private function isStaff(Authenticatable $user): bool
     {
-        return app('gate')->allows('canManageBlog', $user);
+        return app(Gate::class)->allows('canManageBlog', $user);
     }
 }

--- a/src/Providers/BlogServiceProvider.php
+++ b/src/Providers/BlogServiceProvider.php
@@ -74,5 +74,11 @@ final class BlogServiceProvider extends PackageServiceProvider
                     ->cron((string) config('blog.scheduler.cron', '* * * * *'));
             });
         }
+
+        // Register the module's REST API. This is a no-op unless
+        // `blog.http.mode` is `api` or `ui`; when enabled it wires the
+        // `blog-api` rate limiter and loads routes/api.php inside the
+        // config-driven route group (prefix + throttle).
+        $this->registerModuleApi(__DIR__.'/../../routes/api.php');
     }
 }

--- a/tests/Api/AuthorizationTest.php
+++ b/tests/Api/AuthorizationTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Tests\Fixtures\PanelUser;
+
+it('blocks guests from write endpoints', function () {
+    $this->postJson('/api/blog/posts', ['title' => 'Sneaky'])->assertUnauthorized();
+});
+
+it('denies a non-owner, non-staff user from updating a post (403)', function () {
+    $author = PanelUser::create(['email' => 'author@example.com']);
+    $post = Post::factory()->published()->create(['user_id' => $author->id]);
+
+    $other = PanelUser::create(['email' => 'other@example.com']);
+    $this->actingAs($other);
+
+    $this->patchJson('/api/blog/posts/'.$post->id, ['title' => 'Hijacked'])->assertForbidden();
+});
+
+it('denies a non-staff user from creating a category (403)', function () {
+    $user = PanelUser::create(['email' => 'user@example.com']);
+    $this->actingAs($user);
+
+    $this->postJson('/api/blog/categories', ['name' => 'Nope'])->assertForbidden();
+});

--- a/tests/Api/CategoryTest.php
+++ b/tests/Api/CategoryTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Gate;
+use Kurt\Modules\Blog\Models\Category;
+use Kurt\Modules\Blog\Tests\Fixtures\PanelUser;
+
+it('performs full category CRUD as staff', function () {
+    $staff = PanelUser::create(['email' => 'staff@example.com']);
+    Gate::define('canManageBlog', fn ($user) => (int) $user->getAuthIdentifier() === (int) $staff->id);
+    $this->actingAs($staff);
+
+    $created = $this->postJson('/api/blog/categories', ['name' => 'News'])
+        ->assertCreated()
+        ->assertJsonPath('data.name', 'News');
+
+    $id = $created->json('data.id');
+
+    $this->getJson('/api/blog/categories/'.$id)->assertOk()->assertJsonPath('data.name', 'News');
+
+    $this->patchJson('/api/blog/categories/'.$id, ['name' => 'Updates'])
+        ->assertOk()
+        ->assertJsonPath('data.name', 'Updates');
+
+    $this->deleteJson('/api/blog/categories/'.$id)->assertNoContent();
+
+    expect(Category::withTrashed()->findOrFail($id)->trashed())->toBeTrue();
+});
+
+it('lists categories publicly', function () {
+    Category::factory()->create();
+
+    $this->getJson('/api/blog/categories')
+        ->assertOk()
+        ->assertJsonPath('meta.pagination.total', 1);
+});

--- a/tests/Api/CommentTest.php
+++ b/tests/Api/CommentTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Models\Comment;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Tests\Fixtures\PanelUser;
+
+it('stores a comment on a post and deletes it', function () {
+    $author = PanelUser::create(['email' => 'author@example.com']);
+    $post = Post::factory()->published()->create(['user_id' => $author->id]);
+
+    $commenter = PanelUser::create(['email' => 'commenter@example.com']);
+    $this->actingAs($commenter);
+
+    $created = $this->postJson('/api/blog/posts/'.$post->id.'/comments', ['body' => 'Nice post'])
+        ->assertCreated()
+        ->assertJsonPath('data.body', 'Nice post')
+        ->assertJsonPath('data.post_id', $post->id);
+
+    $commentId = $created->json('data.id');
+
+    // The comment's author may delete it.
+    $this->deleteJson('/api/blog/comments/'.$commentId)->assertNoContent();
+
+    expect(Comment::withTrashed()->findOrFail($commentId)->trashed())->toBeTrue();
+});
+
+it('lists only approved comments for a post to guests', function () {
+    $author = PanelUser::create(['email' => 'author@example.com']);
+    $post = Post::factory()->published()->create(['user_id' => $author->id]);
+
+    Comment::factory()->approved()->create(['post_id' => $post->id, 'user_id' => $author->id]);
+    Comment::factory()->create(['post_id' => $post->id, 'user_id' => $author->id]); // pending
+
+    $this->getJson('/api/blog/posts/'.$post->id.'/comments')
+        ->assertOk()
+        ->assertJsonPath('meta.pagination.total', 1);
+});

--- a/tests/Api/PostCrudTest.php
+++ b/tests/Api/PostCrudTest.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Models\Tag;
+use Kurt\Modules\Blog\Tests\Fixtures\PanelUser;
+
+it('creates, updates and deletes a post as the author', function () {
+    $author = PanelUser::create(['email' => 'author@example.com']);
+    $tag = Tag::factory()->create();
+    $this->actingAs($author);
+
+    $created = $this->postJson('/api/blog/posts', [
+        'title' => 'My First Post',
+        'body' => 'Hello body',
+        'tags' => [$tag->id],
+    ])->assertCreated();
+
+    $id = $created->json('data.id');
+
+    expect($created->json('data.status'))->toBe('draft')
+        ->and($created->json('data.author_id'))->toBe($author->id)
+        ->and($created->json('data.tags'))->toHaveCount(1);
+
+    $this->patchJson('/api/blog/posts/'.$id, ['title' => 'Updated Title'])
+        ->assertOk()
+        ->assertJsonPath('data.title', 'Updated Title');
+
+    $this->deleteJson('/api/blog/posts/'.$id)->assertNoContent();
+
+    expect(Post::withTrashed()->findOrFail($id)->trashed())->toBeTrue();
+});

--- a/tests/Api/PostIndexTest.php
+++ b/tests/Api/PostIndexTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Models\Category;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Tests\Fixtures\PanelUser;
+
+it('lists published posts with filter, sort and pagination', function () {
+    $author = PanelUser::create(['email' => 'author@example.com']);
+    $catA = Category::factory()->create();
+    $catB = Category::factory()->create();
+
+    Post::factory()->published()->create(['user_id' => $author->id, 'category_id' => $catA->id, 'title' => ['en' => 'Alpha']]);
+    Post::factory()->published()->create(['user_id' => $author->id, 'category_id' => $catA->id, 'title' => ['en' => 'Bravo']]);
+    Post::factory()->published()->create(['user_id' => $author->id, 'category_id' => $catB->id, 'title' => ['en' => 'Charlie']]);
+
+    // A draft must never surface for a guest.
+    Post::factory()->create(['user_id' => $author->id, 'title' => ['en' => 'Hidden Draft']]);
+
+    // Filter by category (friendly alias -> category_id column).
+    $this->getJson('/api/blog/posts?filter[category]='.$catA->id)
+        ->assertOk()
+        ->assertJsonPath('meta.pagination.total', 2);
+
+    // Sort by title ascending.
+    $titles = array_column(
+        $this->getJson('/api/blog/posts?sort=title')->assertOk()->json('data'),
+        'title',
+    );
+    expect($titles)->toBe(['Alpha', 'Bravo', 'Charlie']);
+
+    // Paginate.
+    $this->getJson('/api/blog/posts?per_page=2')
+        ->assertOk()
+        ->assertJsonPath('meta.pagination.per_page', 2)
+        ->assertJsonPath('meta.pagination.total', 3)
+        ->assertJsonCount(2, 'data');
+});
+
+it('excludes drafts from the guest listing', function () {
+    $author = PanelUser::create(['email' => 'author@example.com']);
+    Post::factory()->create(['user_id' => $author->id]);
+
+    $this->getJson('/api/blog/posts')
+        ->assertOk()
+        ->assertJsonPath('meta.pagination.total', 0);
+});

--- a/tests/Api/PostPublishTest.php
+++ b/tests/Api/PostPublishTest.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Event;
+use Kurt\Modules\Blog\Events\PostPublished;
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Tests\Fixtures\PanelUser;
+
+it('publishes and unpublishes a post', function () {
+    Event::fake([PostPublished::class]);
+
+    $author = PanelUser::create(['email' => 'author@example.com']);
+    $post = Post::factory()->create(['user_id' => $author->id]);
+    $this->actingAs($author);
+
+    $this->postJson('/api/blog/posts/'.$post->id.'/publish')
+        ->assertOk()
+        ->assertJsonPath('data.status', 'published');
+
+    expect($post->fresh()->published_at)->not->toBeNull();
+    Event::assertDispatched(PostPublished::class);
+
+    $this->postJson('/api/blog/posts/'.$post->id.'/unpublish')
+        ->assertOk()
+        ->assertJsonPath('data.status', 'draft');
+});

--- a/tests/Api/PostRelatedTest.php
+++ b/tests/Api/PostRelatedTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Models\Tag;
+use Kurt\Modules\Blog\Tests\Fixtures\PanelUser;
+
+it('returns posts related by shared tags', function () {
+    $author = PanelUser::create(['email' => 'author@example.com']);
+    $tag = Tag::factory()->create();
+
+    $base = Post::factory()->published()->create(['user_id' => $author->id]);
+    $base->tags()->attach($tag->id);
+
+    $related = Post::factory()->published()->create(['user_id' => $author->id]);
+    $related->tags()->attach($tag->id);
+
+    $unrelated = Post::factory()->published()->create(['user_id' => $author->id]);
+
+    $ids = array_column(
+        $this->getJson('/api/blog/posts/'.$base->id.'/related')->assertOk()->json('data'),
+        'id',
+    );
+
+    expect($ids)->toContain($related->id)
+        ->not->toContain($unrelated->id)
+        ->not->toContain($base->id);
+});

--- a/tests/Api/PostShowTest.php
+++ b/tests/Api/PostShowTest.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+use Kurt\Modules\Blog\Models\Post;
+use Kurt\Modules\Blog\Tests\Fixtures\PanelUser;
+
+it('shows a published post by id and by slug', function () {
+    $author = PanelUser::create(['email' => 'author@example.com']);
+    $post = Post::factory()->published()->create(['user_id' => $author->id, 'title' => ['en' => 'Hello World']]);
+
+    $this->getJson('/api/blog/posts/'.$post->id)
+        ->assertOk()
+        ->assertJsonPath('data.id', $post->id)
+        ->assertJsonPath('data.title', 'Hello World');
+
+    $this->getJson('/api/blog/posts/'.$post->slug)
+        ->assertOk()
+        ->assertJsonPath('data.slug', $post->slug);
+});
+
+it('forbids a guest from viewing a draft', function () {
+    $author = PanelUser::create(['email' => 'author@example.com']);
+    $post = Post::factory()->create(['user_id' => $author->id]);
+
+    $this->getJson('/api/blog/posts/'.$post->id)->assertForbidden();
+});
+
+it('returns 404 for an unknown post', function () {
+    $this->getJson('/api/blog/posts/does-not-exist')->assertNotFound();
+});

--- a/tests/Api/TagTest.php
+++ b/tests/Api/TagTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Support\Facades\Gate;
+use Kurt\Modules\Blog\Models\Tag;
+use Kurt\Modules\Blog\Tests\Fixtures\PanelUser;
+
+it('lists and shows tags publicly', function () {
+    $tag = Tag::factory()->create();
+
+    $this->getJson('/api/blog/tags')
+        ->assertOk()
+        ->assertJsonPath('meta.pagination.total', 1);
+
+    $this->getJson('/api/blog/tags/'.$tag->id)
+        ->assertOk()
+        ->assertJsonPath('data.id', $tag->id);
+});
+
+it('lets staff create and delete tags', function () {
+    $staff = PanelUser::create(['email' => 'staff@example.com']);
+    Gate::define('canManageBlog', fn ($user) => (int) $user->getAuthIdentifier() === (int) $staff->id);
+    $this->actingAs($staff);
+
+    $created = $this->postJson('/api/blog/tags', ['name' => 'laravel'])->assertCreated();
+
+    $this->deleteJson('/api/blog/tags/'.$created->json('data.id'))->assertNoContent();
+});

--- a/tests/ApiTestCase.php
+++ b/tests/ApiTestCase.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Kurt\Modules\Blog\Tests;
+
+use Illuminate\Foundation\Application;
+
+/**
+ * Test case for the REST API suite. Flips `blog.http.mode` to `api` in
+ * defineEnvironment (before the providers boot) so BlogServiceProvider's
+ * registerModuleApi() actually registers routes/api.php for these tests.
+ */
+abstract class ApiTestCase extends TestCase
+{
+    /**
+     * @param  Application  $app
+     */
+    protected function defineEnvironment($app): void
+    {
+        parent::defineEnvironment($app);
+
+        $app['config']->set('blog.http.mode', 'api');
+    }
+}

--- a/tests/Feature/Http/HeadlessModeTest.php
+++ b/tests/Feature/Http/HeadlessModeTest.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+// This test intentionally uses the default TestCase (not ApiTestCase), so
+// blog.http.mode stays at its `headless` default and no API routes register.
+
+it('registers no API routes in headless mode', function () {
+    expect(config('blog.http.mode'))->toBe('headless');
+
+    $this->getJson('/api/blog/posts')->assertNotFound();
+    $this->postJson('/api/blog/posts', ['title' => 'x'])->assertNotFound();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -5,9 +5,15 @@ declare(strict_types=1);
 use Filament\Forms\Form;
 use Filament\Schemas\Schema;
 use Filament\Tables\Table;
+use Kurt\Modules\Blog\Tests\ApiTestCase;
 use Kurt\Modules\Blog\Tests\TestCase;
 
 pest()->extend(TestCase::class)->in('Feature');
+
+// The REST API suite lives in its own directory (sibling to Feature so it does
+// not overlap the Feature-wide binding above) and uses ApiTestCase, which flips
+// blog.http.mode to `api` before the providers boot so routes/api.php registers.
+pest()->extend(ApiTestCase::class)->in('Api');
 
 /*
 |--------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Adds an opt-in JSON REST API to the (otherwise headless) Blog module, built entirely on the Core v2.2 API kit (`ApiController`, `HandlesApiQuery`, `ApiRouteGroup`, `registerModuleApi()`).

**Safe by default:** mode stays `headless`, so nothing registers until a consumer sets `BLOG_HTTP_MODE=api`.

Bumps `ozankurt/laravel-modules-core` to `^2.2` (the kit ships in Core 2.2.0).

## What's included

- **config/blog.php** — `http` block (`mode`/`prefix`/`middleware`/`auth_middleware`/`rate_limit`).
- **BlogServiceProvider** — `registerModuleApi(__DIR__.'/../../routes/api.php')`.
- **routes/api.php** — read routes plain (wrapped by the kit's read group: `api/blog` prefix + `throttle:blog-api`); write routes append `config('blog.http.auth_middleware')` per route (no nested `ApiRouteGroup`).
- **src/Http** — thin `ApiController` controllers, `JsonResource` resources, and FormRequests for Posts, Categories, Tags, Comments.
- Reads are public and respect the published scope (guests/non-staff see published only; authors also see own drafts; staff see all). Writes require auth and are enforced by the module Policies via `$this->authorize()`.

### Endpoints (prefix `/api/blog`)

- **Posts:** `GET /posts` (sort `created_at`/`published_at`/`title`; filter `category`/`status`/`author`; paginate), `GET /posts/{id|slug}`, `POST /posts`, `PATCH|PUT /posts/{id|slug}`, `DELETE /posts/{id|slug}`, `POST /posts/{id|slug}/publish`, `POST /posts/{id|slug}/unpublish`, `GET /posts/{id|slug}/related`
- **Comments:** `GET /posts/{id|slug}/comments`, `POST /posts/{id|slug}/comments`, `PATCH|PUT /comments/{id}`, `DELETE /comments/{id}`
- **Categories:** `GET /categories`, `GET /categories/{id}`, `POST /categories`, `PATCH|PUT /categories/{id}`, `DELETE /categories/{id}`
- **Tags:** `GET /tags`, `GET /tags/{id}`, `POST /tags`, `DELETE /tags/{id}`

## Incidental fix

The module Policies resolved the access gate via the unbound `app('gate')` container alias. Blog was headless, so `isStaff()` was never invoked through a Policy until this API — the call throws `Target class [gate] does not exist`. Switched to `app(\Illuminate\Contracts\Auth\Access\Gate::class)` (same semantics) so the `canManageBlog` staff check works.

## Tests

New `tests/Api` suite (mode flipped to `api` in `ApiTestCase::defineEnvironment`): posts index (sort+filter+pagination), show by id/slug, store(201)/update/destroy(204), publish/unpublish (asserts `PostPublished`), related, comments store/destroy + approved-only listing, category CRUD, tag list/create/delete, guest write → 401, policy denial → 403, plus a headless-mode test asserting routes are **not** registered (404).

## Gates

- Pint: clean on changed files
- PHPStan level 8: no errors
- Pest: green (92 passed, 34 Filament-matrix skips). Coverage not run locally (unavailable); verified with plain pest.