### PR TITLE
docs: document requirements, toolchain and CI in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
 # laravel-modules-blog
 
+[![tests](https://github.com/OzanKurt/laravel-modules-blog/actions/workflows/tests.yml/badge.svg)](https://github.com/OzanKurt/laravel-modules-blog/actions/workflows/tests.yml)
+
 Headless blog module for Laravel: posts, categories, tags, comments, scheduled publishing, SEO meta, translatable content, Spatie medialibrary.
 
 ## Requirements
 
-- PHP 8.4+
-- Laravel 13.x
+- PHP `^8.4`
+- Laravel `^13.0`
 - `ozankurt/laravel-modules-core` v2.x (ships the API kit)
 
 ## Installation
@@ -235,6 +237,19 @@ What the resources give you:
   swatch column.
 - **Comments** — a moderation queue defaulting to pending, with approve/reject
   row actions and approve/reject/delete bulk actions.
+
+## Testing
+
+```bash
+composer install
+vendor/bin/pint --test
+vendor/bin/phpstan analyse --memory-limit=2G
+vendor/bin/pest
+```
+
+CI runs the same checks on every push and pull request
+(`.github/workflows/tests.yml`), against PHP 8.4 / Laravel 13. Static analysis
+is held at **PHPStan level 8**; the suite runs on **Pest 5**.
 
 ## License
 


### PR DESCRIPTION
Adds, derived from each package's own `composer.json` and workflow rather than assumed:

- a CI status badge
- a **Requirements** section (PHP `^8.4`, Laravel `^13.0`)
- a **Testing** section listing the checks CI actually enforces (Pint, PHPStan level 8, Pest 5)

Also repoints links at the post-rename `laravel-modules-core` repo. That includes the composer `repositories` VCS snippet, which pointed at the old `KurtModules-Core` path and therefore 404'd for anyone following the install instructions.

Docs only, no code change, so no version bump is needed.